### PR TITLE
feat/[CHAT2]REQ-FOLLOW-004-Redis 저장

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,14 +264,82 @@ Follow this strict development sequence for implementing features:
 
 2. **Refactoring Implementation**:
    - Apply Strategy Pattern for extensible behavior (see `ResponseProcessor` pattern)
-   - Extract common logic to utility classes (see `TravelParsingUtils`)
+   - Extract common logic to utility classes (see `TravelParsingUtils`, `TravelInfoValidator`)
    - Use `@Primary` annotation to override legacy implementations
    - Consolidate duplicate parsing and validation logic
+   - Centralize constants to avoid magic numbers (see `TravelConstants`)
 
 3. **Quality Verification**:
    - Run all unit tests after refactoring
    - Ensure CI pipeline passes
    - Document refactoring decisions in code comments
+
+### Clean Code Guidelines for Code Review
+**IMPORTANT**: Write code that is easy for other team members to review:
+
+1. **Readability First**:
+   - Use descriptive variable and method names
+   - Keep methods short (ideally < 20 lines)
+   - One method should do one thing well
+   - Avoid deep nesting (max 3 levels)
+
+2. **Clear Structure**:
+   - Follow consistent code formatting
+   - Group related functionality together
+   - Use proper spacing and indentation
+   - Add blank lines between logical sections
+
+3. **Self-Documenting Code**:
+   - Code should explain itself without excessive comments
+   - Use meaningful constants instead of magic numbers
+   - Extract complex conditions into well-named methods
+   - Use enums for fixed sets of values
+
+4. **Dependency Management**:
+   - Use dependency injection consistently
+   - Avoid circular dependencies
+   - Keep coupling loose between components
+   - Use interfaces for abstraction
+
+5. **Error Handling**:
+   - Use specific exceptions, not generic ones
+   - Provide meaningful error messages
+   - Handle edge cases explicitly
+   - Use Optional for nullable returns
+
+6. **Testing**:
+   - Write tests that clearly show what's being tested
+   - Use descriptive test method names (Korean is OK for clarity)
+   - Test one behavior per test method
+   - Include both positive and negative test cases
+
+Example of clean code:
+```java
+// BAD
+public void proc(String s, int n) {
+    if(s!=null&&n>0&&n<365) {
+        // complex logic here
+    }
+}
+
+// GOOD
+public void processTravel(String destination, int durationDays) {
+    if (!isValidTravelRequest(destination, durationDays)) {
+        throw new InvalidTravelRequestException(
+            String.format("Invalid travel request: destination=%s, duration=%d", 
+                         destination, durationDays)
+        );
+    }
+    // process travel logic
+}
+
+private boolean isValidTravelRequest(String destination, int durationDays) {
+    return destination != null && 
+           !destination.trim().isEmpty() &&
+           durationDays >= TravelConstants.MIN_DURATION_DAYS &&
+           durationDays <= TravelConstants.MAX_DURATION_DAYS;
+}
+```
 
 ### Database ERD Updates
 - Any structural changes to the database must be reflected in `/docs/DATABASE_ERD.md`
@@ -353,8 +421,10 @@ Current Implementation Status (CHAT2 Team):
 - ✅ REQ-PROMPT-001, 002, 003: Template system completed
 - ✅ REQ-LLM-004: Personalization models implemented
 - ✅ REQ-AI-003: Basic itinerary templates (Day Trip, 1N2D, 2N3D, 3N4D) implemented
+- ✅ REQ-FOLLOW-002, 003, 004: Follow-up question system with flow engine
+- ✅ REQ-FOLLOW-005: Travel info validation system with 3-level verification
 - ✅ CI/CD issues resolved with test separation strategy
-- ✅ Unit tests: 100% passing (SimpleKeywordDetectorTest, TravelHistoryTest, ItineraryTemplatesTest)
+- ✅ Unit tests: 100% passing (including TravelInfoValidatorTest, TravelInfoCollectionServiceTest)
 
 Current focus areas:
 - Implementing RAG-based personalization

--- a/src/main/java/com/compass/config/RedisConfig.java
+++ b/src/main/java/com/compass/config/RedisConfig.java
@@ -1,12 +1,23 @@
 package com.compass.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import java.time.Duration;
+
 @Configuration
+@EnableCaching
+@ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "true", matchIfMissing = true)
 public class RedisConfig {
 
     @Bean
@@ -17,5 +28,31 @@ public class RedisConfig {
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
         return template;
+    }
+    
+    @Bean
+    public RedisTemplate<String, String> stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+    
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+        
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
     }
 }

--- a/src/main/java/com/compass/domain/chat/constant/TravelConstants.java
+++ b/src/main/java/com/compass/domain/chat/constant/TravelConstants.java
@@ -54,4 +54,14 @@ public final class TravelConstants {
     public static final String GROUP_TYPE_COUPLE = "couple";
     public static final String GROUP_TYPE_FAMILY = "family";
     public static final String GROUP_TYPE_FRIENDS = "friends";
+    
+    // 검증 관련 상수
+    public static final int MIN_STRING_LENGTH = 2;
+    public static final int MAX_DURATION_DAYS = 365;
+    public static final int MIN_DURATION_DAYS = 1;
+    public static final int MAX_TRAVELERS = 20;
+    public static final int MIN_TRAVELERS = 1;
+    public static final int MIN_BUDGET = 10000;       // 1만원
+    public static final int MAX_BUDGET = 10000000;    // 1000만원
+    public static final int MAX_ADVANCE_BOOKING_DAYS = 365;  // 최대 1년 후까지 예약 가능
 }

--- a/src/main/java/com/compass/domain/chat/constant/TravelConstants.java
+++ b/src/main/java/com/compass/domain/chat/constant/TravelConstants.java
@@ -1,0 +1,57 @@
+package com.compass.domain.chat.constant;
+
+/**
+ * 여행 정보 수집 관련 상수 정의
+ * 중복된 상수 정의를 방지하고 중앙화된 관리를 위한 클래스
+ */
+public final class TravelConstants {
+    
+    private TravelConstants() {
+        // 인스턴스 생성 방지
+    }
+    
+    // 세션 관련 상수
+    public static final int SESSION_TIMEOUT_HOURS = 24;
+    public static final long CACHE_TTL_MINUTES = 30;
+    public static final String CACHE_KEY_PREFIX = "travel:collection:";
+    
+    // 질문 플로우 관련 상수
+    public static final int REQUIRED_QUESTIONS_WITHOUT_ORIGIN = 5;
+    public static final int REQUIRED_QUESTIONS_WITH_ORIGIN = 6;
+    
+    // 컨텍스트 관리 관련 상수
+    public static final int MAX_CONVERSATION_MESSAGES = 10;
+    public static final int MAX_CONTEXT_TOKENS = 8000;
+    public static final int AVG_CHARS_PER_TOKEN = 4;
+    
+    // 기본값
+    public static final String DEFAULT_DESTINATION = "Seoul";
+    public static final String DEFAULT_BUDGET_LEVEL = "moderate";
+    public static final String DEFAULT_COMPANION_TYPE = "solo";
+    public static final int DEFAULT_DURATION_NIGHTS = 2;
+    public static final int DEFAULT_NUMBER_OF_TRAVELERS = 1;
+    public static final String DEFAULT_CURRENCY = "KRW";
+    
+    // 여행 스타일
+    public static final String TRAVEL_STYLE_RELAXED = "relaxed";
+    public static final String TRAVEL_STYLE_ACTIVE = "active";
+    public static final String TRAVEL_STYLE_ADVENTUROUS = "adventurous";
+    public static final String TRAVEL_STYLE_LUXURY = "luxury";
+    
+    // 예산 레벨
+    public static final String BUDGET_LEVEL_BUDGET = "budget";
+    public static final String BUDGET_LEVEL_MODERATE = "moderate";
+    public static final String BUDGET_LEVEL_LUXURY = "luxury";
+    
+    // 여행 목적
+    public static final String TRIP_PURPOSE_LEISURE = "leisure";
+    public static final String TRIP_PURPOSE_BUSINESS = "business";
+    public static final String TRIP_PURPOSE_HONEYMOON = "honeymoon";
+    public static final String TRIP_PURPOSE_FAMILY = "family vacation";
+    
+    // 그룹 타입
+    public static final String GROUP_TYPE_SOLO = "solo";
+    public static final String GROUP_TYPE_COUPLE = "couple";
+    public static final String GROUP_TYPE_FAMILY = "family";
+    public static final String GROUP_TYPE_FRIENDS = "friends";
+}

--- a/src/main/java/com/compass/domain/chat/controller/TravelInfoCollectionController.java
+++ b/src/main/java/com/compass/domain/chat/controller/TravelInfoCollectionController.java
@@ -3,6 +3,7 @@ package com.compass.domain.chat.controller;
 import com.compass.domain.chat.dto.FollowUpQuestionDto;
 import com.compass.domain.chat.dto.TravelInfoStatusDto;
 import com.compass.domain.chat.dto.TripPlanningRequest;
+import com.compass.domain.chat.dto.ValidationResult;
 import com.compass.domain.chat.service.TravelInfoCollectionService;
 import com.compass.domain.user.repository.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
@@ -196,6 +197,26 @@ public class TravelInfoCollectionController {
         
         collectionService.cancelCollection(sessionId);
         return ResponseEntity.noContent().build();
+    }
+    
+    /**
+     * 현재 수집 상태 검증
+     * REQ-FOLLOW-005: 실시간 검증 API
+     */
+    @GetMapping("/validate-collection/{sessionId}")
+    @Operation(summary = "수집 상태 검증", description = "현재까지 수집된 정보의 유효성을 검증합니다")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "검증 결과 반환",
+                content = @Content(schema = @Schema(implementation = ValidationResult.class))),
+        @ApiResponse(responseCode = "404", description = "세션을 찾을 수 없음")
+    })
+    public ResponseEntity<ValidationResult> validateCollection(
+            @PathVariable String sessionId) {
+        
+        log.info("Validating collection for session: {}", sessionId);
+        
+        ValidationResult validationResult = collectionService.validateCurrentState(sessionId);
+        return ResponseEntity.ok(validationResult);
     }
     
     // === Request/Response DTOs ===

--- a/src/main/java/com/compass/domain/chat/dto/ValidationResult.java
+++ b/src/main/java/com/compass/domain/chat/dto/ValidationResult.java
@@ -1,0 +1,151 @@
+package com.compass.domain.chat.dto;
+
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 여행 정보 검증 결과 DTO
+ * REQ-FOLLOW-005: 필수 필드 입력 완성도 검증 결과
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValidationResult {
+    
+    /**
+     * 전체 검증 성공 여부
+     */
+    private boolean valid;
+    
+    /**
+     * 필드별 오류 메시지
+     * key: 필드명, value: 오류 메시지
+     */
+    @Builder.Default
+    private Map<String, String> fieldErrors = new HashMap<>();
+    
+    /**
+     * 사용자에게 제공할 개선 제안
+     */
+    @Builder.Default
+    private List<String> suggestions = new ArrayList<>();
+    
+    /**
+     * 완성도 백분율 (0-100)
+     */
+    private int completionPercentage;
+    
+    /**
+     * 미완성 필드 목록
+     */
+    @Builder.Default
+    private List<String> incompleteFields = new ArrayList<>();
+    
+    /**
+     * 검증 수준
+     */
+    private ValidationLevel validationLevel;
+    
+    /**
+     * 검증 수준 열거형
+     */
+    public enum ValidationLevel {
+        BASIC,      // 기본 검증 (null, 빈 값)
+        STANDARD,   // 표준 검증 (형식, 범위)
+        STRICT      // 엄격한 검증 (비즈니스 규칙)
+    }
+    
+    /**
+     * 오류 추가 헬퍼 메서드
+     */
+    public void addFieldError(String field, String error) {
+        if (fieldErrors == null) {
+            fieldErrors = new HashMap<>();
+        }
+        fieldErrors.put(field, error);
+    }
+    
+    /**
+     * 제안 추가 헬퍼 메서드
+     */
+    public void addSuggestion(String suggestion) {
+        if (suggestions == null) {
+            suggestions = new ArrayList<>();
+        }
+        suggestions.add(suggestion);
+    }
+    
+    /**
+     * 미완성 필드 추가 헬퍼 메서드
+     */
+    public void addIncompleteField(String field) {
+        if (incompleteFields == null) {
+            incompleteFields = new ArrayList<>();
+        }
+        incompleteFields.add(field);
+    }
+    
+    /**
+     * 특정 필드에 오류가 있는지 확인
+     */
+    public boolean hasFieldError(String field) {
+        return fieldErrors != null && fieldErrors.containsKey(field);
+    }
+    
+    /**
+     * 오류가 있는지 확인
+     */
+    public boolean hasErrors() {
+        return fieldErrors != null && !fieldErrors.isEmpty();
+    }
+    
+    /**
+     * 사용자 친화적인 메시지 생성
+     */
+    public String getUserFriendlyMessage() {
+        if (valid) {
+            return "모든 필수 정보가 올바르게 입력되었습니다.";
+        }
+        
+        StringBuilder message = new StringBuilder();
+        message.append("다음 정보를 확인해 주세요:\n");
+        
+        if (fieldErrors != null && !fieldErrors.isEmpty()) {
+            fieldErrors.forEach((field, error) -> {
+                message.append("• ").append(getFieldDisplayName(field))
+                       .append(": ").append(error).append("\n");
+            });
+        }
+        
+        if (suggestions != null && !suggestions.isEmpty()) {
+            message.append("\n💡 제안사항:\n");
+            suggestions.forEach(suggestion -> 
+                message.append("• ").append(suggestion).append("\n")
+            );
+        }
+        
+        return message.toString();
+    }
+    
+    /**
+     * 필드명을 사용자 친화적인 이름으로 변환
+     */
+    private String getFieldDisplayName(String field) {
+        return switch (field) {
+            case "origin" -> "출발지";
+            case "destination" -> "목적지";
+            case "startDate" -> "출발일";
+            case "endDate" -> "도착일";
+            case "duration" -> "여행 기간";
+            case "companions" -> "동행자";
+            case "budget" -> "예산";
+            default -> field;
+        };
+    }
+}

--- a/src/main/java/com/compass/domain/chat/service/TravelInfoCollectionCacheService.java
+++ b/src/main/java/com/compass/domain/chat/service/TravelInfoCollectionCacheService.java
@@ -1,0 +1,131 @@
+package com.compass.domain.chat.service;
+
+import com.compass.domain.chat.entity.TravelInfoCollectionState;
+import com.compass.domain.chat.constant.TravelConstants;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 여행 정보 수집 상태 캐시 서비스
+ * REQ-FOLLOW-004: Redis 저장 | TravelContext 30분 TTL
+ * 
+ * Redis를 활용한 임시 저장소로 30분 TTL 관리
+ * Redis가 비활성화된 경우 자동으로 무시됨
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "true", matchIfMissing = true)
+public class TravelInfoCollectionCacheService {
+    
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+    
+    
+    @Value("${travel.collection.cache.ttl:30}")
+    private long cacheTtlMinutes = TravelConstants.CACHE_TTL_MINUTES;
+    
+    /**
+     * 여행 정보 수집 상태를 Redis에 저장
+     * 30분 TTL 자동 설정
+     */
+    public void saveTravelContext(String sessionId, TravelInfoCollectionState state) {
+        try {
+            String key = TravelConstants.CACHE_KEY_PREFIX + sessionId;
+            String value = objectMapper.writeValueAsString(state);
+            
+            redisTemplate.opsForValue().set(
+                key, 
+                value, 
+                cacheTtlMinutes, 
+                TimeUnit.MINUTES
+            );
+            
+            log.debug("Travel context cached with sessionId: {}, TTL: {} minutes", 
+                     sessionId, cacheTtlMinutes);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize travel context for caching: {}", sessionId, e);
+        } catch (Exception e) {
+            log.warn("Redis caching failed for sessionId: {}, continuing without cache", sessionId, e);
+        }
+    }
+    
+    /**
+     * Redis에서 여행 정보 수집 상태 조회
+     */
+    public Optional<TravelInfoCollectionState> getTravelContext(String sessionId) {
+        try {
+            String key = TravelConstants.CACHE_KEY_PREFIX + sessionId;
+            String value = redisTemplate.opsForValue().get(key);
+            
+            if (value != null) {
+                TravelInfoCollectionState state = objectMapper.readValue(
+                    value, 
+                    TravelInfoCollectionState.class
+                );
+                log.debug("Travel context retrieved from cache for sessionId: {}", sessionId);
+                return Optional.of(state);
+            }
+        } catch (JsonProcessingException e) {
+            log.error("Failed to deserialize travel context from cache: {}", sessionId, e);
+        } catch (Exception e) {
+            log.warn("Redis retrieval failed for sessionId: {}, falling back to DB", sessionId, e);
+        }
+        
+        return Optional.empty();
+    }
+    
+    /**
+     * Redis에서 여행 정보 수집 상태 삭제
+     */
+    public void deleteTravelContext(String sessionId) {
+        try {
+            String key = TravelConstants.CACHE_KEY_PREFIX + sessionId;
+            Boolean deleted = redisTemplate.delete(key);
+            
+            if (Boolean.TRUE.equals(deleted)) {
+                log.debug("Travel context removed from cache for sessionId: {}", sessionId);
+            }
+        } catch (Exception e) {
+            log.warn("Redis deletion failed for sessionId: {}, continuing", sessionId, e);
+        }
+    }
+    
+    /**
+     * TTL 갱신 (활성 세션 유지)
+     */
+    public void refreshTTL(String sessionId) {
+        try {
+            String key = TravelConstants.CACHE_KEY_PREFIX + sessionId;
+            Boolean success = redisTemplate.expire(key, cacheTtlMinutes, TimeUnit.MINUTES);
+            
+            if (Boolean.TRUE.equals(success)) {
+                log.debug("TTL refreshed for sessionId: {}", sessionId);
+            }
+        } catch (Exception e) {
+            log.warn("TTL refresh failed for sessionId: {}", sessionId, e);
+        }
+    }
+    
+    /**
+     * 캐시 존재 여부 확인
+     */
+    public boolean exists(String sessionId) {
+        try {
+            String key = TravelConstants.CACHE_KEY_PREFIX + sessionId;
+            return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+        } catch (Exception e) {
+            log.warn("Redis existence check failed for sessionId: {}", sessionId, e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/compass/domain/chat/util/TravelInfoValidator.java
+++ b/src/main/java/com/compass/domain/chat/util/TravelInfoValidator.java
@@ -1,0 +1,417 @@
+package com.compass.domain.chat.util;
+
+import com.compass.domain.chat.constant.TravelConstants;
+import com.compass.domain.chat.dto.ValidationResult;
+import com.compass.domain.chat.entity.TravelInfoCollectionState;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * 여행 정보 검증 유틸리티
+ * REQ-FOLLOW-005: 필수 필드 입력 완성도 검증
+ */
+@Slf4j
+@Component
+public class TravelInfoValidator {
+    
+    // 검증 상수들은 TravelConstants에서 가져옴
+    
+    /**
+     * 전체 여행 정보 검증
+     */
+    public ValidationResult validate(TravelInfoCollectionState state) {
+        return validate(state, ValidationResult.ValidationLevel.STANDARD);
+    }
+    
+    /**
+     * 지정된 수준으로 여행 정보 검증
+     */
+    public ValidationResult validate(TravelInfoCollectionState state, ValidationResult.ValidationLevel level) {
+        ValidationResult result = ValidationResult.builder()
+                .valid(true)
+                .validationLevel(level)
+                .build();
+        
+        // 각 필드 검증
+        validateOrigin(state, result, level);
+        validateDestination(state, result, level);
+        validateDates(state, result, level);
+        validateDuration(state, result, level);
+        validateCompanions(state, result, level);
+        validateBudget(state, result, level);
+        
+        // 완성도 계산
+        result.setCompletionPercentage(state.getCompletionPercentage());
+        
+        // 전체 검증 결과 설정
+        result.setValid(result.getFieldErrors().isEmpty());
+        
+        // 개선 제안 추가
+        if (!result.isValid()) {
+            addSuggestions(result, state);
+        }
+        
+        log.info("Validation result - Valid: {}, Completion: {}%, Errors: {}", 
+                result.isValid(), result.getCompletionPercentage(), result.getFieldErrors().size());
+        
+        return result;
+    }
+    
+    /**
+     * 출발지 검증
+     */
+    private void validateOrigin(TravelInfoCollectionState state, ValidationResult result, 
+                                ValidationResult.ValidationLevel level) {
+        if (!state.isOriginCollected()) {
+            result.addIncompleteField("origin");
+            result.addFieldError("origin", "출발지를 입력해주세요");
+            return;
+        }
+        
+        String origin = state.getOrigin();
+        if (origin == null || origin.trim().isEmpty()) {
+            result.addFieldError("origin", "출발지를 입력해주세요");
+            return;
+        }
+        
+        if (level != ValidationResult.ValidationLevel.BASIC) {
+            if (origin.trim().length() < TravelConstants.MIN_STRING_LENGTH) {
+                result.addFieldError("origin", "출발지는 최소 2자 이상 입력해주세요");
+            }
+        }
+    }
+    
+    /**
+     * 목적지 검증
+     */
+    private void validateDestination(TravelInfoCollectionState state, ValidationResult result,
+                                     ValidationResult.ValidationLevel level) {
+        if (!state.isDestinationCollected()) {
+            result.addIncompleteField("destination");
+            result.addFieldError("destination", "목적지를 입력해주세요");
+            return;
+        }
+        
+        String destination = state.getDestination();
+        if (destination == null || destination.trim().isEmpty()) {
+            result.addFieldError("destination", "목적지를 입력해주세요");
+            return;
+        }
+        
+        if (level != ValidationResult.ValidationLevel.BASIC) {
+            if (destination.trim().length() < TravelConstants.MIN_STRING_LENGTH) {
+                result.addFieldError("destination", "목적지는 최소 2자 이상 입력해주세요");
+            }
+            
+            // STRICT 수준에서 출발지와 목적지 동일 체크
+            if (level == ValidationResult.ValidationLevel.STRICT) {
+                if (state.getOrigin() != null && 
+                    state.getOrigin().equalsIgnoreCase(destination)) {
+                    result.addFieldError("destination", "출발지와 목적지가 동일합니다");
+                }
+            }
+        }
+    }
+    
+    /**
+     * 날짜 검증
+     */
+    private void validateDates(TravelInfoCollectionState state, ValidationResult result,
+                               ValidationResult.ValidationLevel level) {
+        if (!state.isDatesCollected()) {
+            result.addIncompleteField("dates");
+            result.addFieldError("dates", "여행 날짜를 입력해주세요");
+            return;
+        }
+        
+        LocalDate startDate = state.getStartDate();
+        LocalDate endDate = state.getEndDate();
+        
+        if (startDate == null) {
+            result.addFieldError("startDate", "출발일을 입력해주세요");
+            return;
+        }
+        
+        if (endDate == null) {
+            result.addFieldError("endDate", "도착일을 입력해주세요");
+            return;
+        }
+        
+        if (level != ValidationResult.ValidationLevel.BASIC) {
+            LocalDate today = LocalDate.now();
+            
+            // 과거 날짜 체크
+            if (startDate.isBefore(today)) {
+                result.addFieldError("startDate", "출발일은 오늘 이후여야 합니다");
+            }
+            
+            // 날짜 순서 체크
+            if (endDate.isBefore(startDate)) {
+                result.addFieldError("dates", "도착일이 출발일보다 빠릅니다");
+            }
+            
+            // STRICT 수준에서 추가 검증
+            if (level == ValidationResult.ValidationLevel.STRICT) {
+                // 너무 먼 미래 체크
+                long daysUntilStart = ChronoUnit.DAYS.between(today, startDate);
+                if (daysUntilStart > TravelConstants.MAX_ADVANCE_BOOKING_DAYS) {
+                    result.addFieldError("startDate", 
+                        String.format("출발일은 최대 %d일 이내여야 합니다", TravelConstants.MAX_ADVANCE_BOOKING_DAYS));
+                }
+            }
+        }
+    }
+    
+    /**
+     * 기간 검증
+     */
+    private void validateDuration(TravelInfoCollectionState state, ValidationResult result,
+                                  ValidationResult.ValidationLevel level) {
+        if (!state.isDurationCollected()) {
+            result.addIncompleteField("duration");
+            result.addFieldError("duration", "여행 기간을 입력해주세요");
+            return;
+        }
+        
+        Integer durationNights = state.getDurationNights();
+        if (durationNights == null) {
+            result.addFieldError("duration", "여행 기간을 입력해주세요");
+            return;
+        }
+        
+        if (level != ValidationResult.ValidationLevel.BASIC) {
+            // 먼저 범위 검증
+            if (durationNights < TravelConstants.MIN_DURATION_DAYS) {
+                result.addFieldError("duration", 
+                    String.format("여행 기간은 최소 %d일 이상이어야 합니다", TravelConstants.MIN_DURATION_DAYS));
+                return; // 더 이상 검증하지 않음
+            }
+            
+            if (durationNights > TravelConstants.MAX_DURATION_DAYS) {
+                result.addFieldError("duration", 
+                    String.format("여행 기간은 최대 %d일까지 가능합니다", TravelConstants.MAX_DURATION_DAYS));
+                return; // 더 이상 검증하지 않음
+            }
+            
+            // 날짜와 기간 일치 검증 (범위가 유효한 경우에만)
+            if (state.getStartDate() != null && state.getEndDate() != null) {
+                long calculatedNights = ChronoUnit.DAYS.between(state.getStartDate(), state.getEndDate());
+                if (calculatedNights != durationNights) {
+                    result.addFieldError("duration", 
+                        String.format("날짜 기준 기간(%d일)과 입력된 기간(%d일)이 일치하지 않습니다", 
+                            calculatedNights, durationNights));
+                }
+            }
+        }
+    }
+    
+    /**
+     * 동행자 검증
+     */
+    private void validateCompanions(TravelInfoCollectionState state, ValidationResult result,
+                                    ValidationResult.ValidationLevel level) {
+        if (!state.isCompanionsCollected()) {
+            result.addIncompleteField("companions");
+            result.addFieldError("companions", "동행자 정보를 입력해주세요");
+            return;
+        }
+        
+        Integer numberOfTravelers = state.getNumberOfTravelers();
+        if (numberOfTravelers == null) {
+            result.addFieldError("companions", "여행 인원을 입력해주세요");
+            return;
+        }
+        
+        if (level != ValidationResult.ValidationLevel.BASIC) {
+            if (numberOfTravelers < TravelConstants.MIN_TRAVELERS) {
+                result.addFieldError("companions", 
+                    String.format("여행 인원은 최소 %d명 이상이어야 합니다", TravelConstants.MIN_TRAVELERS));
+            }
+            
+            if (numberOfTravelers > TravelConstants.MAX_TRAVELERS) {
+                result.addFieldError("companions", 
+                    String.format("여행 인원은 최대 %d명까지 가능합니다", TravelConstants.MAX_TRAVELERS));
+            }
+            
+            // 동행자 타입 검증
+            String companionType = state.getCompanionType();
+            if (companionType == null || companionType.trim().isEmpty()) {
+                result.addFieldError("companions", "동행자 유형을 선택해주세요");
+            } else if (level == ValidationResult.ValidationLevel.STRICT) {
+                // 동행자 타입과 인원 수 일치 검증
+                validateCompanionTypeConsistency(companionType, numberOfTravelers, result);
+            }
+        }
+    }
+    
+    /**
+     * 예산 검증
+     */
+    private void validateBudget(TravelInfoCollectionState state, ValidationResult result,
+                                ValidationResult.ValidationLevel level) {
+        if (!state.isBudgetCollected()) {
+            result.addIncompleteField("budget");
+            result.addFieldError("budget", "예산 정보를 입력해주세요");
+            return;
+        }
+        
+        // 예산 레벨 또는 금액 중 하나는 있어야 함
+        String budgetLevel = state.getBudgetLevel();
+        Integer budgetPerPerson = state.getBudgetPerPerson();
+        
+        if ((budgetLevel == null || budgetLevel.trim().isEmpty()) && budgetPerPerson == null) {
+            result.addFieldError("budget", "예산 수준 또는 금액을 입력해주세요");
+            return;
+        }
+        
+        if (level != ValidationResult.ValidationLevel.BASIC && budgetPerPerson != null) {
+            if (budgetPerPerson < TravelConstants.MIN_BUDGET) {
+                result.addFieldError("budget", 
+                    String.format("예산은 최소 %,d원 이상이어야 합니다", TravelConstants.MIN_BUDGET));
+            }
+            
+            if (budgetPerPerson > TravelConstants.MAX_BUDGET) {
+                result.addFieldError("budget", 
+                    String.format("예산은 최대 %,d원까지 가능합니다", TravelConstants.MAX_BUDGET));
+            }
+            
+            // STRICT 수준에서 예산과 기간 일치성 검증
+            if (level == ValidationResult.ValidationLevel.STRICT && state.getDurationNights() != null) {
+                validateBudgetReasonableness(budgetPerPerson, state.getDurationNights(), 
+                                            budgetLevel, result);
+            }
+        }
+    }
+    
+    /**
+     * 동행자 타입과 인원 수 일치성 검증
+     */
+    private void validateCompanionTypeConsistency(String companionType, int numberOfTravelers,
+                                                  ValidationResult result) {
+        switch (companionType.toLowerCase()) {
+            case "solo" -> {
+                if (numberOfTravelers != 1) {
+                    result.addFieldError("companions", 
+                        "혼자 여행시 인원은 1명이어야 합니다");
+                }
+            }
+            case "couple" -> {
+                if (numberOfTravelers != 2) {
+                    result.addFieldError("companions", 
+                        "커플 여행시 인원은 2명이어야 합니다");
+                }
+            }
+            case "family" -> {
+                if (numberOfTravelers < 2) {
+                    result.addFieldError("companions", 
+                        "가족 여행시 인원은 2명 이상이어야 합니다");
+                }
+            }
+            case "friends" -> {
+                if (numberOfTravelers < 2) {
+                    result.addFieldError("companions", 
+                        "친구와 여행시 인원은 2명 이상이어야 합니다");
+                }
+            }
+        }
+    }
+    
+    /**
+     * 예산 합리성 검증
+     */
+    private void validateBudgetReasonableness(int budgetPerPerson, int durationNights,
+                                             String budgetLevel, ValidationResult result) {
+        int dailyBudget = budgetPerPerson / (durationNights + 1);
+        
+        // 예산 레벨과 실제 금액 일치성 검증
+        if (budgetLevel != null) {
+            switch (budgetLevel.toLowerCase()) {
+                case "budget" -> {
+                    if (dailyBudget > 200000) {
+                        result.addSuggestion("일일 예산이 20만원을 초과합니다. '적당한' 또는 '럭셔리' 수준을 고려해보세요");
+                    }
+                }
+                case "moderate" -> {
+                    if (dailyBudget < 50000) {
+                        result.addSuggestion("일일 예산이 5만원 미만입니다. '알뜰한' 수준을 고려해보세요");
+                    } else if (dailyBudget > 500000) {
+                        result.addSuggestion("일일 예산이 50만원을 초과합니다. '럭셔리' 수준을 고려해보세요");
+                    }
+                }
+                case "luxury" -> {
+                    if (dailyBudget < 200000) {
+                        result.addSuggestion("일일 예산이 20만원 미만입니다. '적당한' 수준을 고려해보세요");
+                    }
+                }
+            }
+        }
+        
+        // 극단적인 예산 경고
+        if (dailyBudget < 30000) {
+            result.addSuggestion("일일 예산이 매우 적습니다. 숙박과 식사 비용을 고려해 예산을 재검토해주세요");
+        }
+    }
+    
+    /**
+     * 개선 제안 추가
+     */
+    private void addSuggestions(ValidationResult result, TravelInfoCollectionState state) {
+        // 날짜 관련 제안
+        if (state.getStartDate() != null && state.getEndDate() == null && 
+            state.getDurationNights() != null) {
+            result.addSuggestion(String.format("출발일 기준으로 %d박 %d일 여행시 도착일은 %s입니다",
+                state.getDurationNights(), state.getDurationNights() + 1,
+                state.getStartDate().plusDays(state.getDurationNights())));
+        }
+        
+        // 예산 관련 제안
+        if (state.getBudgetPerPerson() == null && state.getBudgetLevel() != null) {
+            String suggestedRange = switch (state.getBudgetLevel().toLowerCase()) {
+                case "budget" -> "10만원~30만원";
+                case "moderate" -> "30만원~100만원";
+                case "luxury" -> "100만원 이상";
+                default -> "예산 범위";
+            };
+            result.addSuggestion(String.format("%s 수준의 일반적인 예산은 %s입니다",
+                state.getBudgetLevel(), suggestedRange));
+        }
+        
+        // 완성도 제안
+        int completionPercentage = state.getCompletionPercentage();
+        if (completionPercentage < 50) {
+            result.addSuggestion("여행 계획을 위해 더 많은 정보가 필요합니다");
+        } else if (completionPercentage < 100) {
+            result.addSuggestion(String.format("현재 %d%%가 완성되었습니다. 조금만 더 입력해주세요!", 
+                completionPercentage));
+        }
+    }
+    
+    /**
+     * 단일 필드 검증
+     */
+    public boolean validateField(String fieldName, Object value) {
+        if (value == null) {
+            return false;
+        }
+        
+        return switch (fieldName.toLowerCase()) {
+            case "origin", "destination" -> 
+                value instanceof String && ((String) value).trim().length() >= TravelConstants.MIN_STRING_LENGTH;
+            case "startdate", "enddate" -> 
+                value instanceof LocalDate && !((LocalDate) value).isBefore(LocalDate.now());
+            case "duration" -> 
+                value instanceof Integer && ((Integer) value) >= TravelConstants.MIN_DURATION_DAYS && 
+                ((Integer) value) <= TravelConstants.MAX_DURATION_DAYS;
+            case "companions", "numberoftravelers" -> 
+                value instanceof Integer && ((Integer) value) >= TravelConstants.MIN_TRAVELERS && 
+                ((Integer) value) <= TravelConstants.MAX_TRAVELERS;
+            case "budget", "budgetperperson" -> 
+                value instanceof Integer && ((Integer) value) >= TravelConstants.MIN_BUDGET && 
+                ((Integer) value) <= TravelConstants.MAX_BUDGET;
+            default -> true;
+        };
+    }
+}

--- a/src/test/java/com/compass/domain/chat/service/TravelInfoCollectionCacheServiceTest.java
+++ b/src/test/java/com/compass/domain/chat/service/TravelInfoCollectionCacheServiceTest.java
@@ -1,0 +1,177 @@
+package com.compass.domain.chat.service;
+
+import com.compass.domain.chat.entity.TravelInfoCollectionState;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * REQ-FOLLOW-004: Redis 저장 | TravelContext 30분 TTL 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+@Tag("unit")
+@DisplayName("TravelInfoCollectionCacheService 테스트")
+class TravelInfoCollectionCacheServiceTest {
+    
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+    
+    @Mock
+    private ObjectMapper objectMapper;
+    
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+    
+    @InjectMocks
+    private TravelInfoCollectionCacheService cacheService;
+    
+    private TravelInfoCollectionState testState;
+    private String sessionId;
+    private String cacheKey;
+    
+    @BeforeEach
+    void setUp() {
+        sessionId = "test-session-123";
+        cacheKey = "travel:collection:" + sessionId;
+        
+        testState = TravelInfoCollectionState.builder()
+                .sessionId(sessionId)
+                .destination("서울")
+                .destinationCollected(true)
+                .durationNights(2)
+                .durationCollected(true)
+                .build();
+        
+        // TTL 설정
+        ReflectionTestUtils.setField(cacheService, "cacheTtlMinutes", 30L);
+    }
+    
+    @Test
+    @DisplayName("여행 컨텍스트를 Redis에 저장하고 30분 TTL을 설정한다")
+    void saveTravelContext_Success() throws Exception {
+        // given
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        String jsonValue = "{\"sessionId\":\"test-session-123\"}";
+        when(objectMapper.writeValueAsString(testState)).thenReturn(jsonValue);
+        
+        // when
+        cacheService.saveTravelContext(sessionId, testState);
+        
+        // then
+        verify(valueOperations).set(cacheKey, jsonValue, 30L, TimeUnit.MINUTES);
+    }
+    
+    @Test
+    @DisplayName("직렬화 실패 시 로그만 남기고 계속 진행한다")
+    void saveTravelContext_SerializationFailure() throws Exception {
+        // given
+        when(objectMapper.writeValueAsString(testState))
+                .thenThrow(new RuntimeException("Serialization error"));
+        
+        // when
+        cacheService.saveTravelContext(sessionId, testState);
+        
+        // then
+        verify(valueOperations, never()).set(anyString(), anyString(), anyLong(), any(TimeUnit.class));
+    }
+    
+    @Test
+    @DisplayName("Redis에서 여행 컨텍스트를 조회한다")
+    void getTravelContext_Success() throws Exception {
+        // given
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        String jsonValue = "{\"sessionId\":\"test-session-123\"}";
+        when(valueOperations.get(cacheKey)).thenReturn(jsonValue);
+        when(objectMapper.readValue(jsonValue, TravelInfoCollectionState.class))
+                .thenReturn(testState);
+        
+        // when
+        Optional<TravelInfoCollectionState> result = cacheService.getTravelContext(sessionId);
+        
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getSessionId()).isEqualTo(sessionId);
+    }
+    
+    @Test
+    @DisplayName("캐시에 데이터가 없으면 빈 Optional을 반환한다")
+    void getTravelContext_NotFound() {
+        // given
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(cacheKey)).thenReturn(null);
+        
+        // when
+        Optional<TravelInfoCollectionState> result = cacheService.getTravelContext(sessionId);
+        
+        // then
+        assertThat(result).isEmpty();
+    }
+    
+    @Test
+    @DisplayName("TTL을 30분으로 갱신한다")
+    void refreshTTL_Success() {
+        // given
+        when(redisTemplate.expire(cacheKey, 30L, TimeUnit.MINUTES)).thenReturn(true);
+        
+        // when
+        cacheService.refreshTTL(sessionId);
+        
+        // then
+        verify(redisTemplate).expire(cacheKey, 30L, TimeUnit.MINUTES);
+    }
+    
+    @Test
+    @DisplayName("Redis에서 여행 컨텍스트를 삭제한다")
+    void deleteTravelContext_Success() {
+        // given
+        when(redisTemplate.delete(cacheKey)).thenReturn(true);
+        
+        // when
+        cacheService.deleteTravelContext(sessionId);
+        
+        // then
+        verify(redisTemplate).delete(cacheKey);
+    }
+    
+    @Test
+    @DisplayName("캐시 존재 여부를 확인한다")
+    void exists_ReturnsTrue() {
+        // given
+        when(redisTemplate.hasKey(cacheKey)).thenReturn(true);
+        
+        // when
+        boolean exists = cacheService.exists(sessionId);
+        
+        // then
+        assertThat(exists).isTrue();
+    }
+    
+    @Test
+    @DisplayName("Redis 장애 시 false를 반환한다")
+    void exists_RedisFailure_ReturnsFalse() {
+        // given
+        when(redisTemplate.hasKey(cacheKey)).thenThrow(new RuntimeException("Redis error"));
+        
+        // when
+        boolean exists = cacheService.exists(sessionId);
+        
+        // then
+        assertThat(exists).isFalse();
+    }
+}

--- a/src/test/java/com/compass/domain/chat/service/TravelInfoCollectionServiceTest.java
+++ b/src/test/java/com/compass/domain/chat/service/TravelInfoCollectionServiceTest.java
@@ -244,7 +244,7 @@ class TravelInfoCollectionServiceTest {
         assertThatThrownBy(() -> 
                 service.completeCollection("TIC_TEST1234"))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("아직 모든 정보가 수집되지 않았습니다");
+                .hasMessageContaining("다음 정보가 필요합니다");
     }
     
     @Test

--- a/src/test/java/com/compass/domain/chat/util/TravelInfoValidatorTest.java
+++ b/src/test/java/com/compass/domain/chat/util/TravelInfoValidatorTest.java
@@ -1,0 +1,299 @@
+package com.compass.domain.chat.util;
+
+import com.compass.domain.chat.dto.ValidationResult;
+import com.compass.domain.chat.entity.TravelInfoCollectionState;
+import com.compass.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * REQ-FOLLOW-005: 필수 필드 입력 검증 테스트
+ */
+@Tag("unit")
+@DisplayName("TravelInfoValidator 테스트")
+class TravelInfoValidatorTest {
+    
+    private TravelInfoValidator validator;
+    private TravelInfoCollectionState validState;
+    private User mockUser;
+    
+    @BeforeEach
+    void setUp() {
+        validator = new TravelInfoValidator();
+        mockUser = mock(User.class);
+        
+        // 유효한 상태 생성
+        validState = TravelInfoCollectionState.builder()
+                .user(mockUser)
+                .sessionId("TEST_SESSION_001")
+                .origin("서울")
+                .originCollected(true)
+                .destination("부산")
+                .destinationCollected(true)
+                .startDate(LocalDate.now().plusDays(7))
+                .endDate(LocalDate.now().plusDays(9))
+                .datesCollected(true)
+                .durationNights(2)
+                .durationCollected(true)
+                .numberOfTravelers(2)
+                .companionType("couple")
+                .companionsCollected(true)
+                .budgetPerPerson(500000)
+                .budgetLevel("moderate")
+                .budgetCurrency("KRW")
+                .budgetCollected(true)
+                .build();
+    }
+    
+    @Test
+    @DisplayName("모든 필드가 유효한 경우 검증 성공")
+    void validateAllFieldsValid() {
+        // when
+        ValidationResult result = validator.validate(validState);
+        
+        // then
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.getFieldErrors()).isEmpty();
+        assertThat(result.getCompletionPercentage()).isEqualTo(100);
+    }
+    
+    @Test
+    @DisplayName("필수 필드 누락시 검증 실패")
+    void validateMissingRequiredFields() {
+        // given
+        TravelInfoCollectionState incompleteState = TravelInfoCollectionState.builder()
+                .user(mockUser)
+                .sessionId("TEST_SESSION_002")
+                .destination("제주도")
+                .destinationCollected(true)
+                .build();
+        
+        // when
+        ValidationResult result = validator.validate(incompleteState);
+        
+        // then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getFieldErrors()).isNotEmpty();
+        assertThat(result.getIncompleteFields()).contains("origin", "dates", "duration", "companions", "budget");
+        assertThat(result.getCompletionPercentage()).isLessThan(100);
+    }
+    
+    @Test
+    @DisplayName("빈 문자열 필드 검증 실패")
+    void validateEmptyStringFields() {
+        // given
+        validState.setDestination("");
+        
+        // when
+        ValidationResult result = validator.validate(validState);
+        
+        // then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.hasFieldError("destination")).isTrue();
+        assertThat(result.getFieldErrors().get("destination")).contains("입력해주세요");
+    }
+    
+    @Test
+    @DisplayName("날짜 순서 검증 - 도착일이 출발일보다 빠른 경우")
+    void validateDateOrder() {
+        // given
+        validState.setStartDate(LocalDate.now().plusDays(10));
+        validState.setEndDate(LocalDate.now().plusDays(5));
+        
+        // when
+        ValidationResult result = validator.validate(validState);
+        
+        // then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.hasFieldError("dates")).isTrue();
+        assertThat(result.getFieldErrors().get("dates")).contains("도착일이 출발일보다 빠릅니다");
+    }
+    
+    @Test
+    @DisplayName("과거 날짜 검증 실패")
+    void validatePastDates() {
+        // given
+        validState.setStartDate(LocalDate.now().minusDays(1));
+        validState.setEndDate(LocalDate.now().plusDays(1));
+        
+        // when
+        ValidationResult result = validator.validate(validState);
+        
+        // then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.hasFieldError("startDate")).isTrue();
+        assertThat(result.getFieldErrors().get("startDate")).contains("오늘 이후여야 합니다");
+    }
+    
+    @Test
+    @DisplayName("여행 기간 범위 검증")
+    void validateDurationRange() {
+        // given - 너무 긴 기간
+        validState.setDurationNights(400);
+        
+        // when
+        ValidationResult result = validator.validate(validState);
+        
+        // then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.hasFieldError("duration")).isTrue();
+        assertThat(result.getFieldErrors().get("duration")).contains("최대 365일까지");
+    }
+    
+    @Test
+    @DisplayName("동행자 인원 범위 검증")
+    void validateTravelerCount() {
+        // given - 너무 많은 인원
+        validState.setNumberOfTravelers(25);
+        
+        // when
+        ValidationResult result = validator.validate(validState);
+        
+        // then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.hasFieldError("companions")).isTrue();
+        assertThat(result.getFieldErrors().get("companions")).contains("최대 20명까지");
+    }
+    
+    @Test
+    @DisplayName("예산 범위 검증")
+    void validateBudgetRange() {
+        // given - 너무 적은 예산
+        validState.setBudgetPerPerson(5000);
+        
+        // when
+        ValidationResult result = validator.validate(validState);
+        
+        // then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.hasFieldError("budget")).isTrue();
+        assertThat(result.getFieldErrors().get("budget")).contains("최소");
+    }
+    
+    @Test
+    @DisplayName("STRICT 레벨 - 출발지와 목적지 동일 검증")
+    void validateStrictLevelSameOriginDestination() {
+        // given
+        validState.setOrigin("서울");
+        validState.setDestination("서울");
+        
+        // when
+        ValidationResult result = validator.validate(validState, ValidationResult.ValidationLevel.STRICT);
+        
+        // then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.hasFieldError("destination")).isTrue();
+        assertThat(result.getFieldErrors().get("destination")).contains("출발지와 목적지가 동일");
+    }
+    
+    @Test
+    @DisplayName("STRICT 레벨 - 동행자 타입과 인원 일치성 검증")
+    void validateStrictCompanionConsistency() {
+        // given - solo인데 2명
+        validState.setCompanionType("solo");
+        validState.setNumberOfTravelers(2);
+        
+        // when
+        ValidationResult result = validator.validate(validState, ValidationResult.ValidationLevel.STRICT);
+        
+        // then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.hasFieldError("companions")).isTrue();
+        assertThat(result.getFieldErrors().get("companions")).contains("혼자 여행시 인원은 1명");
+    }
+    
+    @Test
+    @DisplayName("BASIC 레벨 - 기본 검증만 수행")
+    void validateBasicLevel() {
+        // given - 짧은 목적지명 (BASIC에서는 통과)
+        validState.setDestination("A");
+        
+        // when
+        ValidationResult result = validator.validate(validState, ValidationResult.ValidationLevel.BASIC);
+        
+        // then
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.getFieldErrors()).isEmpty();
+    }
+    
+    @Test
+    @DisplayName("개선 제안 생성 검증")
+    void validateSuggestions() {
+        // given - 예산 정보가 없는 상태로 만들기
+        validState.setBudgetPerPerson(null);
+        validState.setBudgetLevel("luxury");
+        validState.setBudgetCollected(false); // 예산이 수집되지 않은 상태로 변경
+        
+        // when
+        ValidationResult result = validator.validate(validState);
+        
+        // then
+        // 검증 실패시 제안이 생성되어야 함
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getSuggestions()).isNotEmpty();
+        // 예산 수준에 대한 제안이 포함되어야 함
+        boolean hasBudgetSuggestion = result.getSuggestions().stream()
+                .anyMatch(s -> s.contains("럭셔리") || s.contains("예산") || s.contains("100만원"));
+        assertThat(hasBudgetSuggestion).isTrue();
+    }
+    
+    @Test
+    @DisplayName("사용자 친화적 메시지 생성")
+    void validateUserFriendlyMessage() {
+        // given
+        validState.setDestinationCollected(false);
+        validState.setDatesCollected(false);
+        
+        // when
+        ValidationResult result = validator.validate(validState);
+        String message = result.getUserFriendlyMessage();
+        
+        // then
+        assertThat(message).contains("다음 정보를 확인해 주세요");
+        assertThat(message).contains("목적지");
+        assertThat(message).contains("여행 날짜");
+    }
+    
+    @Test
+    @DisplayName("단일 필드 검증 - 유효한 값")
+    void validateSingleFieldValid() {
+        // when & then
+        assertThat(validator.validateField("destination", "파리")).isTrue();
+        assertThat(validator.validateField("duration", 5)).isTrue();
+        assertThat(validator.validateField("budget", 300000)).isTrue();
+    }
+    
+    @Test
+    @DisplayName("단일 필드 검증 - 유효하지 않은 값")
+    void validateSingleFieldInvalid() {
+        // when & then
+        assertThat(validator.validateField("destination", "")).isFalse();
+        assertThat(validator.validateField("duration", 500)).isFalse();
+        assertThat(validator.validateField("budget", 100)).isFalse();
+        assertThat(validator.validateField("companions", 0)).isFalse();
+    }
+    
+    @Test
+    @DisplayName("날짜와 기간 일치성 검증")
+    void validateDateDurationConsistency() {
+        // given
+        validState.setStartDate(LocalDate.now().plusDays(1));
+        validState.setEndDate(LocalDate.now().plusDays(5));
+        validState.setDurationNights(2); // 실제는 4박이어야 함
+        
+        // when
+        ValidationResult result = validator.validate(validState);
+        
+        // then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.hasFieldError("duration")).isTrue();
+        assertThat(result.getFieldErrors().get("duration")).contains("일치하지 않습니다");
+    }
+}


### PR DESCRIPTION
# 🎯 완료된 작업: REQ-FOLLOW-003/004 구현 및 리팩토링

## 📋 구현 내용

### 1. REQ-FOLLOW-003: 답변 파싱 | LLM 활용 자연어 처리
- **상태**: ✅ 이미 구현됨
- **위치**: `NaturalLanguageParsingService`, `ResponseProcessor` 구현체들
- **기능**: LLM(Gemini)을 활용한 자연어 파싱 및 Strategy Pattern 기반 응답 처리

### 2. REQ-FOLLOW-004: Redis 저장 | TravelContext 30분 TTL
- **상태**: ✅ 신규 구현 완료
- **구현 내용**:
  - `TravelInfoCollectionCacheService` 신규 생성
  - Redis 캐싱 레이어 추가 (30분 TTL)
  - Graceful fallback 패턴 구현 (Redis 장애 시 JPA 직접 사용)
  - @ConditionalOnProperty로 Redis 옵셔널 처리

### 3. 코드 리팩토링
- **상태**: ✅ 완료
- **개선 사항**:
  - `TravelConstants` 클래스 생성으로 상수 중앙화
  - 중복 정규식 패턴 제거
  - 매직 넘버 제거
  - TravelParsingUtils 활용으로 파싱 로직 통합

## 🔄 사용자 요청 처리 워크플로우

### 전체 흐름 (사용자가 "제주도 3박4일 여행 가고 싶어"라고 입력 시)

1. **요청 수신** (ChatController)
   - POST `/api/chat/travel` 엔드포인트로 요청 도착
   - userId와 메시지를 TravelInfoCollectionService로 전달

2. **캐시 확인** (Redis - 30분 TTL) 🆕
   - Redis에서 해당 세션의 여행 정보 수집 상태 조회
   - 캐시 히트: Redis에서 바로 가져옴
   - 캐시 미스: PostgreSQL에서 조회
   - Redis 장애 시: 자동으로 PostgreSQL만 사용 (Fallback)

3. **자연어 파싱** (NaturalLanguageParsingService)
   - Gemini 2.0 Flash로 사용자 입력 분석
   - "제주도 3박4일" → destination: "제주도", nights: 3, days: 4
   - TravelParsingUtils로 세부 파싱 (날짜, 인원, 예산 등)

4. **응답 처리** (ResponseProcessor - Strategy Pattern)
   - 입력 타입에 따라 적절한 처리기 선택
   - TravelDestinationProcessor: 목적지 처리
   - TravelDatesProcessor: 날짜/기간 처리
   - TravelBudgetProcessor: 예산 처리
   - 각 처리기가 구조화된 데이터로 변환

5. **상태 업데이트**
   - 파싱된 정보를 TravelInfoCollectionState에 저장
   - 수집 완료 여부 체크 (destination ✓, dates ✓, companions ?, budget ?)

6. **다음 질문 생성** (QuestionFlowEngine & FollowUpQuestionGenerator)
   - **⚠️ 중요**: 현재 LLM을 사용하지 않고 규칙 기반으로 동작
   - 하드코딩된 질문 템플릿 사용
   - 예: "몇 명이서 가시나요?" (미리 정의된 문자열)

7. **상태 저장** 🆕
   - Redis 저장 (TTL 30분) - 빠른 접근용
   - PostgreSQL 저장 - 영구 보관용
   - 둘 다 독립적으로 동작 (한쪽 실패해도 OK)

8. **응답 반환**
   - "제주도 3박4일 여행이군요! 몇 명이서 가시나요?"
   - 다음 질문과 함께 수집된 정보 확인 메시지 전송

## 📝 필수 수집 정보 순서

1. **목적지** → 2. **날짜/기간** → 3. **동행자** → 4. **예산** → 5. **출발지** (선택) → 6. **여행 스타일** (선택)

각 단계마다:
- 사용자 입력 → 파싱 → 검증 → 저장 → 다음 질문
- 모든 필수 정보 수집 완료 시 TripPlanningRequest 생성

## 🔄 전체 흐름

  사용자가 "제주도 3박4일 여행 가고 싶어"라고 입력했을 때:

  1. 요청 수신 (ChatController)
    - POST /api/chat/travel 엔드포인트로 요청 도착
    - userId와 메시지를 TravelInfoCollectionService로 전달
  2. 캐시 확인 (Redis - 30분 TTL)
    - Redis에서 해당 세션의 여행 정보 수집 상태 조회
    - 캐시 히트: Redis에서 바로 가져옴
    - 캐시 미스: PostgreSQL에서 조회
    - Redis 장애 시: 자동으로 PostgreSQL만 사용 (Fallback)
  3. 자연어 파싱 (NaturalLanguageParsingService)
    - Gemini 2.0 Flash로 사용자 입력 분석
    - "제주도 3박4일" → destination: "제주도", nights: 3, days: 4
    - TravelParsingUtils로 세부 파싱 (날짜, 인원, 예산 등)
  4. 응답 처리 (ResponseProcessor - Strategy Pattern)
    - 입력 타입에 따라 적절한 처리기 선택
    - TravelDestinationProcessor: 목적지 처리
    - TravelDatesProcessor: 날짜/기간 처리
    - TravelBudgetProcessor: 예산 처리
    - 각 처리기가 구조화된 데이터로 변환
  5. 상태 업데이트
    - 파싱된 정보를 TravelInfoCollectionState에 저장
    - 수집 완료 여부 체크 (destination ✓, dates ✓, companions ?,
  budget ?)
  6. 다음 질문 생성 (QuestionFlowEngine)
    - 현재 수집 상태 확인
    - 아직 수집 안 된 정보 확인
    - FollowUpQuestionGenerator로 자연스러운 질문 생성
    - 예: "몇 명이서 가시나요?"
  7. 상태 저장
    - Redis 저장 (TTL 30분) - 빠른 접근용
    - PostgreSQL 저장 - 영구 보관용
    - 둘 다 독립적으로 동작 (한쪽 실패해도 OK)
  8. 응답 반환
    - "제주도 3박4일 여행이군요! 몇 명이서 가시나요?"
    - 다음 질문과 함께 수집된 정보 확인 메시지 전송

## 🤖 LLM 사용 현황

### LLM을 사용하는 곳
1. **NaturalLanguageParsingService**: 사용자 답변 파싱
2. **ChatModelService**: 일반 대화 응답 생성
3. **FunctionCallingChatService**: 외부 API 호출 필요 시

### LLM을 사용하지 않는 곳
- **FollowUpQuestionGenerator**: ❌ 규칙 기반 (하드코딩된 질문)
  - 모든 질문이 Java 코드에 직접 작성됨
  - switch문으로 단계별 질문 선택
  - 예측 가능하지만 획일적

## 🛡️ 안정성 보장

### Redis 장애 대응
- Redis 연결 실패 → 경고 로그만 남기고 계속 진행
- JPA로 직접 DB 접근하여 서비스 중단 없음
- @ConditionalOnProperty로 Redis 없어도 동작

### 파싱 실패 대응
- LLM 파싱 실패 → TravelParsingUtils fallback
- 정규식 파싱도 실패 → 기본값 사용
- 항상 사용자에게 확인 질문으로 검증

## 💾 데이터 저장 구조

### Redis (캐시) 🆕
- Key: `travel:collection:{sessionId}`
- Value: JSON 직렬화된 TravelInfoCollectionState
- TTL: 30분 (TravelConstants.CACHE_TTL_MINUTES)

### PostgreSQL (영구 저장)
- Table: travel_info_collection_states
- 사용자별 여행 정보 수집 이력 관리
- 완료/미완료 상태 추적

## ⚙️ 핵심 설정값 (TravelConstants) 🆕

- 세션 타임아웃: 24시간
- 캐시 TTL: 30분
- 필수 질문 수: 5개 (출발지 없음) / 6개 (출발지 포함)
- 기본값들: 서울, moderate 예산, solo 여행 등


## ✅ 테스트 결과
- **컴파일**: 성공
- **TravelInfoCollectionCacheServiceTest**: 8/8 통과
- **Unit Tests (Redis 불필요)**: 모두 통과

## 📁 변경된 파일
1. `TravelInfoCollectionCacheService.java` (신규)
2. `TravelConstants.java` (신규)
3. `TravelInfoCollectionService.java` (수정)
4. `RedisConfig.java` (수정)
5. `TravelInfoCollectionCacheServiceTest.java` (신규)

## 🔧 기술적 결정
- Strategy Pattern 유지 (ResponseProcessor)
- Redis Optional with @ConditionalOnProperty
- Graceful Degradation 패턴
- SOLID 원칙 준수 (SRP, OCP)

## 🎯 현재 구현 완료 상태

### ✅ 완료된 기능
- 자연어 파싱 (LLM + Utils)
- Redis 캐싱 (30분 TTL)
- Fallback 메커니즘
- Strategy Pattern 응답 처리
- 상수 중앙화
- 단위 테스트

### 🔄 처리 가능한 시나리오
- 순차적 정보 수집
- 중간 이탈 후 재접속
- Redis 장애 상황
- 다양한 입력 형식
- 부분 정보 입력

