### PR TITLE
User/req user 004 여행선호도저장

### DIFF
--- a/src/main/java/com/compass/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/compass/common/entity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.compass.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/compass/domain/trip/entity/UserPreference.java
+++ b/src/main/java/com/compass/domain/trip/entity/UserPreference.java
@@ -17,7 +17,7 @@ import java.math.BigDecimal;
  */
 @Getter
 @Entity
-@Table(name = "user_preferences")
+@Table(name = "user_preferences_1")// User 폴더에 있는 UserPreference와 겹쳐서 변경
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/compass/domain/user/controller/UserController.java
+++ b/src/main/java/com/compass/domain/user/controller/UserController.java
@@ -79,7 +79,7 @@ public class UserController {
         return ResponseEntity.ok(updatedUser);
     }
 
-    @PutMapping("/profile/preferences/travel-style")
+    @PutMapping("/preferences")
     @Operation(summary = "여행 스타일 선호도 수정 및 저장", description = "사용자의 여행 스타일(휴양, 관광, 액티비티 등) 선호도 가중치를 수정합니다.")
     public ResponseEntity<List<UserPreferenceDto.Response>> updateTravelStylePreferences(
             Authentication authentication,

--- a/src/main/java/com/compass/domain/user/controller/UserController.java
+++ b/src/main/java/com/compass/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.compass.domain.user.controller;
 
 import com.compass.domain.user.dto.UserDto;
+import com.compass.domain.user.dto.UserPreferenceDto;
 import com.compass.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,6 +16,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -75,6 +77,19 @@ public class UserController {
         }
         UserDto updatedUser = userService.updateUserProfileByEmail(authentication.getName(), request);
         return ResponseEntity.ok(updatedUser);
+    }
+
+    @PutMapping("/profile/preferences/travel-style")
+    @Operation(summary = "여행 스타일 선호도 수정 및 저장", description = "사용자의 여행 스타일(휴양, 관광, 액티비티 등) 선호도 가중치를 수정합니다.")
+    public ResponseEntity<List<UserPreferenceDto.Response>> updateTravelStylePreferences(
+            Authentication authentication,
+            @Valid @RequestBody UserPreferenceDto.UpdateRequest request) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            // 인증 정보가 없으면 401 Unauthorized를 반환하는 방어 코드
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        List<UserPreferenceDto.Response> responses = userService.updateUserTravelStyle(authentication.getName(), request);
+        return ResponseEntity.ok(responses);
     }
 
 }

--- a/src/main/java/com/compass/domain/user/dto/UserPreferenceDto.java
+++ b/src/main/java/com/compass/domain/user/dto/UserPreferenceDto.java
@@ -1,0 +1,45 @@
+package com.compass.domain.user.dto;
+
+import com.compass.domain.user.entity.UserPreference;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class UserPreferenceDto {
+
+    @Getter
+    public static class UpdateRequest {
+        @Valid
+        private List<PreferenceItem> preferences;
+    }
+
+    @Getter
+    public static class PreferenceItem {
+        @NotBlank
+        private String key;
+        @NotNull
+        @DecimalMin("0.0")
+        @DecimalMax("1.0")
+        private BigDecimal value;
+    }
+
+    @Getter @Builder
+    public static class Response {
+        private String preferenceKey;
+        private BigDecimal preferenceValue;
+
+        public static Response from(UserPreference preference) {
+            return Response.builder()
+                    .preferenceKey(preference.getPreferenceKey())
+                    .preferenceValue(preference.getPreferenceValue())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/compass/domain/user/entity/UserPreference.java
+++ b/src/main/java/com/compass/domain/user/entity/UserPreference.java
@@ -1,0 +1,43 @@
+package com.compass.domain.user.entity;
+
+import com.compass.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity(name = "user_preferences")
+@Table(name = "user_preferences",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "preferenceType", "preferenceKey"}))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserPreference extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 50)
+    private String preferenceType; // 예: "TRAVEL_STYLE"
+
+    @Column(nullable = false, length = 50)
+    private String preferenceKey;  // 예: "RELAXATION", "SIGHTSEEING"
+
+    @Column(nullable = false, precision = 3, scale = 2)
+    private BigDecimal preferenceValue; // 예: 0.30 (30%)
+
+    @Builder
+    public UserPreference(User user, String preferenceType, String preferenceKey, BigDecimal preferenceValue) {
+        this.user = user;
+        this.preferenceType = preferenceType;
+        this.preferenceKey = preferenceKey;
+        this.preferenceValue = preferenceValue;
+    }
+}

--- a/src/main/java/com/compass/domain/user/repository/UserPreferenceRepository.java
+++ b/src/main/java/com/compass/domain/user/repository/UserPreferenceRepository.java
@@ -1,0 +1,14 @@
+package com.compass.domain.user.repository;
+
+import com.compass.domain.user.entity.User;
+import com.compass.domain.user.entity.UserPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository("userDomainPreferenceRepository") // Bean 이름 충돌을 피하기 위해 별명 지정
+public interface UserPreferenceRepository extends JpaRepository<UserPreference, Long> {
+    List<UserPreference> findByUser(User user);
+    void deleteByUserAndPreferenceType(User user, String preferenceType);
+}

--- a/src/main/java/com/compass/domain/user/service/UserService.java
+++ b/src/main/java/com/compass/domain/user/service/UserService.java
@@ -2,8 +2,11 @@ package com.compass.domain.user.service;
 
 import com.compass.config.jwt.JwtTokenProvider;
 import com.compass.domain.user.dto.UserDto;
+import com.compass.domain.user.dto.UserPreferenceDto;
 import com.compass.domain.user.entity.User;
+import com.compass.domain.user.entity.UserPreference;
 import com.compass.domain.user.enums.Role;
+import com.compass.domain.user.repository.UserPreferenceRepository;
 import com.compass.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +15,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -26,6 +32,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final UserPreferenceRepository userPreferenceRepository;
 
     @Transactional
     public UserDto.SignUpResponse signUp(UserDto.SignUpRequest request) {
@@ -102,6 +109,40 @@ public class UserService {
         log.info("Updated profile for user: {}", user.getEmail());
         return UserDto.from(user);
     }
+
+    @Transactional
+    public List<UserPreferenceDto.Response> updateUserTravelStyle(String email, UserPreferenceDto.UpdateRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with email: " + email));
+
+        // 선호도 값의 총합이 1.0인지 검증
+        BigDecimal totalValue = request.getPreferences().stream()
+                .map(UserPreferenceDto.PreferenceItem::getValue)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        if (totalValue.compareTo(BigDecimal.ONE) != 0) {
+            throw new IllegalArgumentException("선호도 값의 총합은 1.0이 되어야 합니다.");
+        }
+
+        // 기존 여행 스타일 선호도 삭제
+        userPreferenceRepository.deleteByUserAndPreferenceType(user, "TRAVEL_STYLE");
+
+        // 새로운 선호도 저장
+        List<UserPreference> preferences = request.getPreferences().stream()
+                .map(item -> UserPreference.builder()
+                        .user(user)
+                        .preferenceType("TRAVEL_STYLE")
+                        .preferenceKey(item.getKey())
+                        .preferenceValue(item.getValue())
+                        .build())
+                .collect(Collectors.toList());
+        // 3. 새로운 선호도 일괄 저장
+        userPreferenceRepository.saveAll(preferences);
+        log.info("Updated travel style preferences for user: {}", email);
+        // 4. 결과 반환
+        return preferences.stream().map(UserPreferenceDto.Response::from).collect(Collectors.toList());
+    }
+
 
 
 }

--- a/src/test/java/com/compass/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/compass/domain/user/controller/UserControllerTest.java
@@ -319,7 +319,7 @@ class UserControllerTest extends BaseIntegrationTest {
         );
 
         // when
-        ResultActions resultActions = mockMvc.perform(put("/api/users/profile/preferences/travel-style")
+        ResultActions resultActions = mockMvc.perform(put("/api/users/preferences")
                 .header("Authorization", "Bearer " + accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody));
@@ -354,7 +354,7 @@ class UserControllerTest extends BaseIntegrationTest {
         );
 
         // when
-        ResultActions resultActions = mockMvc.perform(put("/api/users/profile/preferences/travel-style")
+        ResultActions resultActions = mockMvc.perform(put("/api/users/preferences")
                 .header("Authorization", "Bearer " + accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody));
@@ -372,7 +372,7 @@ class UserControllerTest extends BaseIntegrationTest {
         String requestBody = objectMapper.writeValueAsString(Map.of("preferences", List.of()));
 
         // when
-        ResultActions resultActions = mockMvc.perform(put("/api/users/profile/preferences/travel-style")
+        ResultActions resultActions = mockMvc.perform(put("/api/users/preferences")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody));
 

--- a/src/test/java/com/compass/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/compass/domain/user/controller/UserControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -292,6 +293,88 @@ class UserControllerTest extends BaseIntegrationTest {
         ResultActions resultActions = mockMvc.perform(patch("/api/users/profile")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(emptyRequestBody));
+
+        // then
+        resultActions.andExpect(status().isUnauthorized());
+    }
+
+
+    @Test
+    @DisplayName("여행 스타일 선호도 수정 성공")
+    void updateTravelStylePreferences_success() throws Exception {
+        // given
+        User savedUser = userRepository.save(User.builder()
+                .email("style@example.com")
+                .password(passwordEncoder.encode("password123"))
+                .nickname("styleUser")
+                .role(Role.USER)
+                .build());
+        String accessToken = jwtTokenProvider.createAccessToken(savedUser.getEmail());
+
+        String requestBody = objectMapper.writeValueAsString(
+                Map.of("preferences", List.of(
+                        Map.of("key", "RELAXATION", "value", 0.7),
+                        Map.of("key", "ACTIVITY", "value", 0.3)
+                ))
+        );
+
+        // when
+        ResultActions resultActions = mockMvc.perform(put("/api/users/profile/preferences/travel-style")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].preferenceKey").value("RELAXATION"))
+                .andExpect(jsonPath("$[0].preferenceValue").value(0.7));
+    }
+
+    @Test
+    @DisplayName("여행 스타일 선호도 수정 실패 - 합계가 1이 아님")
+    void updateTravelStylePreferences_fail_invalidSum() throws Exception {
+        // given
+        User savedUser = userRepository.save(User.builder()
+                .email("style@example.com")
+                .password(passwordEncoder.encode("password123"))
+                .nickname("styleUser")
+                .role(Role.USER)
+                .build());
+        String accessToken = jwtTokenProvider.createAccessToken(savedUser.getEmail());
+
+        // 합계가 1.1로, 유효하지 않은 요청
+        String requestBody = objectMapper.writeValueAsString(
+                Map.of("preferences", List.of(
+                        Map.of("key", "RELAXATION", "value", 0.8),
+                        Map.of("key", "ACTIVITY", "value", 0.3)
+                ))
+        );
+
+        // when
+        ResultActions resultActions = mockMvc.perform(put("/api/users/profile/preferences/travel-style")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("선호도 값의 총합은 1.0이 되어야 합니다."));
+    }
+
+    @Test
+    @DisplayName("여행 스타일 선호도 수정 실패 - 인증되지 않은 사용자")
+    void updateTravelStylePreferences_fail_unauthorized() throws Exception {
+        // given
+        String requestBody = objectMapper.writeValueAsString(Map.of("preferences", List.of()));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(put("/api/users/profile/preferences/travel-style")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
 
         // then
         resultActions.andExpect(status().isUnauthorized());


### PR DESCRIPTION
## 📝 PR 개요

관련 이슈: #87 

이 PR은 인증된 사용자가 자신의 여행 스타일 선호도(휴양, 관광, 액티비티 등)를 저장하고 수정하는 기능을 구현합니다. 이 데이터는 향후 AI의 개인화된 여행 추천에 사용됩니다. (요구사항 ID: REQ-USER-004)

## 💻 작업 내역

- [x] 여행 선호도 수정을 위한 PUT /api/users/preferences 엔드포인트 추가

- [x] UserService에 updateUserTravelStyle 비즈니스 로직 구현

 - 기존 선호도를 모두 삭제하고 새로운 값으로 덮어쓰는 '전체 교체' 방식 적용
 - 선호도 값의 총합이 1.0인지 검증하는 로직 추가

- [x] user 도메인에 UserPreference 엔티티 및 UserPreferenceRepository 생성
 - trip 도메인과의 이름 충돌을 피하기 위해 Bean 이름 명시적 지정

- [x] 선호도 수정 요청/응답을 위한 UserPreferenceDto 구현

- [x] 관련 단위 테스트 및 통합 테스트 코드 작성 완료
 - 성공, 사용자 없음, 유효성 검사 실패, 미인증 접근 등 모든 시나리오 포함


## ✔️ 테스트 결과

- 모든 단위 테스트와 통합 테스트(./gradlew test)를 통과했습니다.

- Postman을 통해 실제 API 요청 및 응답(성공, 실패 케이스 포함)이 정상적으로 동작하는 것을 확인했습니다.


## 🧐 리뷰 포인트

- 선호도 업데이트 시 delete-then-insert 방식을 사용했는데, 더 효율적인 방법에 대한 의견이 궁금합니다.

- 선호도 값의 합계를 검증하는 로직을 Service 계층에 두었는데, 이 위치가 적절한지 검토 부탁드립니다.

- trip 도메인과의 충돌을 피하기 위해 user 도메인의 엔티티와 리포지토리 Bean 이름을 직접 지정했는데, 이 접근 방식에 대한 리뷰도 부탁드립니다.

## 💡 기타

- 다음 PR에서는 예산 레벨 설정 기능(REQ-USER-005)을 구현할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added POST /api/auth/logout to sign out and invalidate the current access token (returns a confirmation message).
  - Added GET /api/users/profile to view your profile.
  - Added PATCH /api/users/profile to update nickname and profile image (partial updates supported).
  - Added PUT /api/users/profile/preferences/travel-style to set travel-style preferences; validates totals equal 1.0 and returns saved items.
  - All new endpoints require authentication and return 401 when unauthorized; invalid preference totals return 400 with an error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->