### PR TITLE
[CHAT1] feat: 키워드 사전 관리 기능 추가

### DIFF
--- a/src/main/java/com/compass/domain/chat/service/KeywordDictionary.java
+++ b/src/main/java/com/compass/domain/chat/service/KeywordDictionary.java
@@ -1,0 +1,51 @@
+package com.compass.domain.chat.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * REQ-INTENT-003: 키워드 사전 관리
+ * HashMap을 기반으로 핵심 키워드와 의도를 매핑하여 관리합니다.
+ * LLM 호출 전에 빠른 경로(Fast Path)를 제공하여 시스템 효율성을 높입니다.
+ */
+@Component
+public class KeywordDictionary {
+
+    private static final Map<String, IntentRouter.Intent> KEYWORD_MAP = new HashMap<>();
+
+    // static 초기화 블록을 사용하여 키워드와 의도를 매핑합니다.
+    static {
+        // 여행 관련 키워드
+        KEYWORD_MAP.put("여행", IntentRouter.Intent.TRIP);
+        KEYWORD_MAP.put("일정", IntentRouter.Intent.TRIP);
+        KEYWORD_MAP.put("계획", IntentRouter.Intent.TRIP);
+        KEYWORD_MAP.put("가려", IntentRouter.Intent.TRIP);
+        KEYWORD_MAP.put("갈까", IntentRouter.Intent.TRIP);
+
+        // 추천 관련 키워드
+        KEYWORD_MAP.put("추천", IntentRouter.Intent.RECOMMENDATION);
+        KEYWORD_MAP.put("알려줘", IntentRouter.Intent.RECOMMENDATION);
+        KEYWORD_MAP.put("맛집", IntentRouter.Intent.RECOMMENDATION);
+        KEYWORD_MAP.put("명소", IntentRouter.Intent.RECOMMENDATION);
+        KEYWORD_MAP.put("찾아줘", IntentRouter.Intent.RECOMMENDATION);
+        KEYWORD_MAP.put("어때", IntentRouter.Intent.RECOMMENDATION);
+    }
+
+    /**
+     * 사용자 입력에 키워드가 포함되어 있는지 확인하여 해당하는 의도를 반환합니다.
+     * @param userInput 사용자 입력 문자열
+     * @return Optional<Intent> 키워드가 존재하면 해당 의도를, 없으면 Optional.empty()를 반환
+     */
+    public Optional<IntentRouter.Intent> findIntent(String userInput) {
+        String normalizedInput = userInput.toLowerCase().replaceAll("\\s+", "");
+        for (Map.Entry<String, IntentRouter.Intent> entry : KEYWORD_MAP.entrySet()) {
+            if (normalizedInput.contains(entry.getKey())) {
+                return Optional.of(entry.getValue());
+            }
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 설명 (Pull Request Description)

**Title:** `✨ Feat: KeywordDictionary를 적용한 하이브리드 IntentRouter 구현`

## #️⃣ 관련 이슈

-   Close # 116

## 📝 주요 변경 사항

1.  **`KeywordDictionary` 신규 추가 (REQ-INTENT-003)**
    -   `HashMap`을 기반으로 핵심 키워드와 의도를 매핑하여 관리하는 `KeywordDictionary` 컴포넌트를 추가했습니다.
    -   "여행", "일정", "추천", "맛집" 등 시스템의 핵심 기능과 직결되는 11개의 명확한 키워드를 사전 정의하여, LLM 호출 없이도 빠르고 정확하게 기본 의도를 파악할 수 있는 기반을 마련했습니다.

2.  **`IntentRouter` 하이브리드 로직으로 리팩토링**
    -   기존의 LLM 단일 호출 방식에서 벗어나, `KeywordDictionary`와 연동하는 하이브리드 방식으로 로직을 개선했습니다.
    -   **새로운 동작 흐름:**
        1.  **(Fast Path)** 사용자 입력이 들어오면 `KeywordDictionary`를 통해 키워드 존재 여부를 먼저 확인합니다.
        2.  키워드 발견 시, 즉시 해당 의도를 반환하고 로직을 종료합니다.
        3.  키워드가 없을 경우에만 **(Precise Path)** 기존처럼 `ChatModelService`를 호출하여 LLM에게 정밀한 의도 분류를 요청합니다.

## ✅ 기대 효과

-   **응답 속도 개선:** 사용자가 일반적인 키워드를 사용했을 때, API 호출 오버헤드 없이 즉각적인 의도 분류가 가능해져 UX가 향상됩니다.
-   **운영 효율성 증대:** 불필요한 LLM API 호출 횟수를 줄여 비용을 절감하고 시스템 부하를 낮춥니다.

## 🧪 테스트 방법

-   **키워드 기반 테스트:** "도쿄 여행 계획 알려줘" → `KeywordDictionary`에 의해 `Intent.TRIP`으로 즉시 분류되어야 함 (LLM 호출 X)
-   **LLM 기반 테스트:** "도쿄에서 분위기 좋은 곳 있을까?" → 키워드가 없으므로 LLM을 통해 `Intent.RECOMMENDATION`으로 분류되어야 함 (LLM 호출 O)