### PR TITLE
Feat/t ask 2.4.3 follow up진행기

### DIFF
--- a/src/main/java/com/compass/domain/chat/function/collection/ContinueFollowUpFunction.java
+++ b/src/main/java/com/compass/domain/chat/function/collection/ContinueFollowUpFunction.java
@@ -1,8 +1,11 @@
 package com.compass.domain.chat.function.collection;
 
 import com.compass.domain.chat.function.followup.FollowUpQuestionSelector;
+import com.compass.domain.chat.model.request.AnalyzeUserInputRequest;
+
 import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
 import com.compass.domain.chat.model.response.ChatResponse;
+import com.compass.domain.chat.model.response.FollowUpResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -13,18 +16,33 @@ import java.util.function.Function;
 @Slf4j
 @Component("continueFollowUp")
 @RequiredArgsConstructor
-public class ContinueFollowUpFunction implements Function<TravelFormSubmitRequest, ChatResponse> {
+public class ContinueFollowUpFunction implements Function<FollowUpResponse, ChatResponse> {
 
+    private final AnalyzeUserInputFunction analyzer; // 사용자 입력 분석기
     private final FollowUpQuestionSelector questionSelector;
 
     @Override
-    public ChatResponse apply(TravelFormSubmitRequest updatedInfo) {
-        log.info("Follow-up 대화 지속 여부를 결정합니다. userId: {}", updatedInfo.userId());
+    public ChatResponse apply(FollowUpResponse response) {
+        log.info("Follow-up 응답을 처리하고 대화를 계속합니다. userId: {}", response.currentInfo().userId());
 
-        // 질문 선택자에게 다음 질문을 찾아달라고 요청
+        // 1. 사용자 답변을 분석하여 TravelInfo를 업데이트
+        TravelFormSubmitRequest updatedInfo = analyzer.apply(
+            new AnalyzeUserInputRequest(response.currentInfo().userId(), response.userInput(), response.currentInfo())
+        );
+
+        // 2. 업데이트된 정보로 다음 질문을 찾음 (완성도 재평가)
         return questionSelector.findNextQuestion(updatedInfo)
-                .map(this::createQuestionResponse) // 질문이 있으면, 다음 질문 응답 생성
-                .orElseGet(() -> { // 질문할 것이 없으면, 정보 수집 완료
+                .map(nextQuestion -> {
+                    // 3-1. 다음 질문이 있으면, 질문을 생성
+                    log.info("다음 Follow-up 질문을 생성합니다: {}", nextQuestion);
+                    return ChatResponse.builder()
+                            .content(nextQuestion)
+                            .type("ASSISTANT_MESSAGE")
+                            .nextAction("AWAIT_USER_INPUT")
+                            .build();
+                })
+                .orElseGet(() -> {
+                    // 3-2. 모든 정보가 수집되었으면, Phase 전환
                     log.info("모든 필수 정보가 수집되었습니다. 여행 계획 생성 단계로 전환합니다. userId: {}", updatedInfo.userId());
                     return ChatResponse.builder()
                             .content("감사합니다! 필요한 정보가 모두 모였습니다. 이제 멋진 여행 계획을 세워드릴게요. 잠시만 기다려주세요.")
@@ -32,14 +50,5 @@ public class ContinueFollowUpFunction implements Function<TravelFormSubmitReques
                             .nextAction("TRIGGER_PLAN_GENERATION")
                             .build();
                 });
-    }
-
-    private ChatResponse createQuestionResponse(String question) {
-        log.info("다음 Follow-up 질문을 생성합니다: {}", question);
-        return ChatResponse.builder()
-                .content(question)
-                .type("ASSISTANT_MESSAGE")
-                .nextAction("AWAIT_USER_INPUT") // 사용자의 다음 입력을 기다림
-                .build();
     }
 }

--- a/src/main/java/com/compass/domain/chat/function/collection/StartFollowUpFunction.java
+++ b/src/main/java/com/compass/domain/chat/function/collection/StartFollowUpFunction.java
@@ -1,13 +1,10 @@
 package com.compass.domain.chat.function.collection;
 
 import com.compass.domain.chat.function.followup.FollowUpQuestionSelector;
-import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
 import com.compass.domain.chat.model.response.ChatResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
-import org.springframework.util.StringUtils;
 
 import java.util.function.Function;
 
@@ -16,35 +13,23 @@ import java.util.function.Function;
 @Slf4j
 @Component("startFollowUp") // nextAction "START_FOLLOW_UP"과 매핑
 @RequiredArgsConstructor
-public class StartFollowUpFunction implements Function<TravelFormSubmitRequest, ChatResponse> {
+public class StartFollowUpFunction implements Function<com.compass.domain.chat.model.request.TravelFormSubmitRequest, ChatResponse> {
 
     private final FollowUpQuestionSelector questionSelector;
 
     @Override
-    public ChatResponse apply(TravelFormSubmitRequest request) {
-        log.info("Follow-up 질문 생성을 시작합니다. userId: {}", request.userId());
+    public ChatResponse apply(com.compass.domain.chat.model.request.TravelFormSubmitRequest incompleteInfo) {
+        log.info("Follow-up 질문 생성을 시작합니다.");
 
         // 질문 선택자에게 다음 질문을 찾아달라고 요청
-        return questionSelector.findNextQuestion(request)
-                .map(this::createQuestionResponse) // 질문이 있으면, 질문 응답 생성
-                .orElseGet(() -> { // 질문할 것이 없으면 (이론적으로는 호출되지 않아야 함)
-                    log.warn("모든 필수 정보가 이미 존재하지만 StartFollowUpFunction이 호출되었습니다. userId: {}", request.userId());
-                    return ChatResponse.builder()
-                            .content("필요한 정보는 모두 확인된 것 같아요. 이제 여행 계획을 세워볼까요?")
-                            .type("ASSISTANT_MESSAGE")
-                            .nextAction("TRIGGER_PLAN_GENERATION")
-                            .build();
-                });
-    }
-
-    private ChatResponse createQuestionResponse(String question) {
-        log.info("다음 Follow-up 질문을 생성합니다: {}", question);
+        String firstQuestion = questionSelector.findNextQuestion(incompleteInfo)
+                .orElse("필요한 정보는 모두 확인된 것 같아요. 이제 여행 계획을 세워볼까요?"); // 방어 코드
+        
+        log.info("첫 Follow-up 질문을 생성합니다: {}", firstQuestion);
         return ChatResponse.builder()
-                .content(question)
+                .content(firstQuestion)
                 .type("ASSISTANT_MESSAGE")
-                .nextAction("TRIGGER_PLAN_GENERATION")
+                .nextAction("AWAIT_USER_INPUT") // 사용자의 다음 입력을 기다림
                 .build();
     }
-
-
 }

--- a/src/main/java/com/compass/domain/chat/function/followup/FollowUpQuestionSelector.java
+++ b/src/main/java/com/compass/domain/chat/function/followup/FollowUpQuestionSelector.java
@@ -5,31 +5,52 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 // 다음에 할 Follow-up 질문을 선택하는 책임을 가진 클래스
 @Component
 public class FollowUpQuestionSelector {
 
-    // 누락된 정보에 대한 다음 질문을 찾아서 반환합니다.
-    // 더 이상 질문할 것이 없으면 비어있는 Optional을 반환합니다.
+    // 질문 생성 규칙을 우선순위대로 정의
+    private final List<Function<TravelFormSubmitRequest, Optional<String>>> questionChecks = List.of(
+            this::checkDestinations,
+            this::checkTravelDates,
+            this::checkDepartureLocation
+    );
+
+
     public Optional<String> findNextQuestion(TravelFormSubmitRequest info) {
-        // 1. 목적지 확인 (가장 중요한 정보)
+        // 정의된 규칙을 순서대로 실행하여 첫 번째로 발견된 질문을 반환합니다.
+        return questionChecks.stream()
+                .map(check -> check.apply(info))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+    }
+
+    // 1. 목적지 확인 규칙
+    private Optional<String> checkDestinations(TravelFormSubmitRequest info) {
         if (CollectionUtils.isEmpty(info.destinations()) || info.destinations().stream().anyMatch("목적지 미정"::equalsIgnoreCase)) {
             return Optional.of("어디로 여행을 떠나고 싶으신가요? 도시 이름을 알려주세요.");
         }
+        return Optional.empty();
+    }
 
-        // 2. 여행 날짜 확인
+    // 2. 여행 날짜 확인 규칙
+    private Optional<String> checkTravelDates(TravelFormSubmitRequest info) {
         if (info.travelDates() == null || info.travelDates().startDate() == null || info.travelDates().endDate() == null) {
             return Optional.of("여행은 언제부터 언제까지 계획하고 계신가요?");
         }
+        return Optional.empty();
+    }
 
-        // 3. 출발지 확인
+    // 3. 출발지 확인 규칙
+    private Optional<String> checkDepartureLocation(TravelFormSubmitRequest info) {
         if (!StringUtils.hasText(info.departureLocation())) {
             return Optional.of("어디서 출발하시는지 알려주시겠어요?");
         }
-
-        // 모든 정보가 다 있으므로 질문할 것이 없음
         return Optional.empty();
     }
 }

--- a/src/main/java/com/compass/domain/chat/model/response/FollowUpResponse.java
+++ b/src/main/java/com/compass/domain/chat/model/response/FollowUpResponse.java
@@ -1,0 +1,9 @@
+package com.compass.domain.chat.model.response;
+
+import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
+
+// ContinueFollowUpFunction의 입력을 정의하는 DTO
+public record FollowUpResponse(
+    TravelFormSubmitRequest currentInfo,
+    String userInput
+) {}


### PR DESCRIPTION
# Pull Request

## 작업 정보

### 작업 유형
- [x] 새로운 기능 (New Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 테스트 추가 (Test)
- [ ] 설정 변경 (Configuration)
- [ ] 기타 (Other)

### 관련 이슈
- Issue #155: Task 2.2.3: Follow-up 로직 리팩토링 및 ContinueFollowUpFunction 구현

### 작업 단위
- [ ] Epic (2-4주)
- [ ] Story (1-2일)
- [x] Task (2-4시간)
- [ ] Sub-task (30분-2시간)

## 변경 사항

### 작업 내용
- **리팩토링**: `StartFollowUpFunction`에 중복되던 질문 생성 로직을 별도의 `FollowUpQuestionSelector` 클래스로 분리했습니다.
- **기능 구현**: `AnalyzeUserInputFunction`이 정보를 업데이트한 후 호출될 `ContinueFollowUpFunction`을 구현하여 대화 루프를 완성했습니다.
- **DTO 추가**: `ContinueFollowUpFunction`의 입력을 명확히 하기 위해 `FollowUpResponse` DTO를 새로 정의했습니다.
- **수정**: `StartFollowUpFunction`이 새로운 `FollowUpQuestionSelector`를 사용하도록 수정하고, 역할을 '첫 질문 생성'으로 단순화했습니다.

### 구현 상세
**위치**:
- `src/main/java/com/compass/domain/chat/function/followup/FollowUpQuestionSelector.java` (신규)
- `src/main/java/com/compass/domain/chat/function/collection/StartFollowUpFunction.java` (수정)
- `src/main/java/com/compass/domain/chat/function/collection/ContinueFollowUpFunction.java` (신규)
- `src/main/java/com/compass/domain/chat/model/response/FollowUpResponse.java` (신규)

**목적**: Follow-up 질문 생성 로직을 중앙에서 관리하고, 각 Function의 역할을 명확히 분리하여 시스템의 유지보수성과 확장성을 높입니다.

**영향범위**: Follow-up 질문 시스템 전체의 구조를 개선하고, `ContinueFollowUpFunction`을 추가하여 대화 흐름을 완성합니다.

## 체크리스트

### PR 규칙 준수
- [x] **최대 300줄**
- [x] **단일 책임** (한 PR = 한 가지 기능/수정)
- [x] **독립성** (개별 테스트 및 롤백 가능)

### Java 17 & Lombok 사용
- [x] DTO는 Record 사용
- [x] Entity는 Lombok 사용 (`@Slf4j`)
- [x] Service는 @RequiredArgsConstructor
- [ ] var는 타입 명확할 때만 사용
- [ ] Switch Expression 활용
- [ ] Text Block 활용

### 코드 품질
- [x] 메서드 20줄 이내
- [x] 클래스 200줄 이내
- [x] 단일 책임 원칙 준수 (질문 선택, 시작, 계속의 책임 분리)
- [x] Optional 활용 (질문 존재 여부 처리)

### 주석 규칙
- [x] `//` 주석만 사용
- [x] 한국어로 작성
- [x] 불필요한 주석 제거
- [x] 코드가 명확하면 주석 생략

### 일관성
- [x] 기존 코드 패턴 준수
- [x] 팀 네이밍 컨벤션 준수
- [x] 점진적 개선

### 테스트
- [ ] 단위 테스트 작성 (다음 PR에서 `Selector` 및 각 Function 테스트 추가 예정)
- [ ] 통합 테스트 작성
- [ ] 모든 테스트 통과

### 문서화
- [ ] README 업데이트
- [ ] API 문서 업데이트
- [x] 주요 변경사항 문서화 (본 PR)

## 주요 구현 내용

### 1. 핵심 리팩토링: `FollowUpQuestionSelector` 분리
"다음에 할 질문을 선택하는 책임"을 가진 별도의 클래스를 생성하여 코드 중복을 제거하고, 질문 로직을 중앙에서 관리합니다.


### 2. 역할이 명확해진 Function들
- **`StartFollowUpFunction`**: 이제 오직 '첫 질문'을 던지는 역할에만 집중합니다.
- **`ContinueFollowUpFunction`**: '사용자 답변 분석'과 '다음 행동 결정'이라는 대화 루프의 핵심을 담당합니다.


## 리뷰어에게
- Follow-up 질문 로직의 중복을 제거하고 각 Function의 역할을 명확히 하기 위해, `FollowUpQuestionSelector`를 도입하고 `StartFollowUpFunction`과 `ContinueFollowUpFunction`을 리팩토링했습니다.
- 이 구조는 단일 책임 원칙을 더 잘 따르며, 향후 질문을 추가하거나 순서를 변경할 때 `FollowUpQuestionSelector`만 수정하면 되므로 유지보수성이 크게 향상됩니다.
- `ContinueFollowUpFunction`의 입력으로 `FollowUpResponse` DTO를 새로 정의하여 데이터 흐름을 명확히 했습니다.
- 리팩토링된 전체 구조와 각 컴포넌트의 역할 분담에 대한 리뷰를 부탁드립니다.

## 배포 고려사항
- 해당 없음

## 다음 작업 예정
1. `FollowUpQuestionSelector` 및 각 Function에 대한 단위 테스트 작성

