### PR TITLE
feat: 2.4.4 목적지 퍼플렉시티 ai 추천 기능 추가

### DIFF
--- a/src/main/java/com/compass/domain/chat/function/planning/RecommendDestinationsFunction.java
+++ b/src/main/java/com/compass/domain/chat/function/planning/RecommendDestinationsFunction.java
@@ -1,0 +1,69 @@
+package com.compass.domain.chat.function.planning;
+
+import com.compass.domain.chat.model.dto.DestinationRecommendationDto;
+import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
+import com.compass.domain.chat.service.PerplexityClient;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+// Task 2.3.1: "목적지 미정" 시 사용자에게 맞춤 목적지를 추천하는 Function
+
+@Slf4j
+@Component("recommendDestinations")
+@RequiredArgsConstructor
+public class RecommendDestinationsFunction implements Function<TravelFormSubmitRequest, DestinationRecommendationDto> {
+
+
+    private final PerplexityClient perplexityClient;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public DestinationRecommendationDto apply(TravelFormSubmitRequest request) {
+        log.info("목적지 추천 기능 실행 (PerplexityClient 사용). 출발지: {}", request.departureLocation());
+
+        List<DestinationRecommendationDto.RecommendedDestination> recommendedDestinations;
+        try {
+            // 1. 프롬프트 생성
+            String prompt = createRecommendationPrompt(request.departureLocation(), request.travelStyle());
+
+            // 2. PerplexityClient를 통해 간단하게 API 호출
+            // PerplexityClient가 이미 응답의 content 부분만 깔끔하게 추출해서 반환.
+            String contentJson = perplexityClient.search(prompt);
+
+            // 3. 클라이언트가 반환한 JSON 배열 문자열을 DTO 리스트로 파싱
+            recommendedDestinations = objectMapper.readValue(contentJson, new TypeReference<>() {});
+
+        } catch (Exception e) {
+            log.error("PerplexityClient 사용 중 오류 발생. 빈 추천 목록을 반환합니다. userId: {}", request.userId(), e);
+            recommendedDestinations = Collections.emptyList();
+        }
+
+        // 4. 최종 결과 DTO 생성
+        return new DestinationRecommendationDto(
+                "이런 곳은 어떠세요? 🗺️",
+                "출발지와 선호하는 여행 스타일에 맞춰 추천해 드려요.",
+                createDistanceOptions(),
+                recommendedDestinations
+        );
+    }
+
+    // Perplexity API에 맞는 프롬프트를 생성하는 헬퍼 메서드
+    private String createRecommendationPrompt(String departure, List<String> styles) {
+        String stylesText = String.join(", ", styles);
+        return String.format(
+                "%s에서 출발하며, %s 스타일의 여행을 즐기는 사람에게 어울리는 국내 여행지 3곳을 추천해줘. 각 장소의 특징과 추천 이유를 간단히 설명하고, 대표 이미지 URL과 관련된 태그를 포함해줘. 반드시 JSON 배열 형식으로만 응답해줘. 다른 부가 설명은 절대 붙이지마.",
+                departure, stylesText
+        );
+    }
+
+    // 거리 기반 선택 옵션을 생성하는 헬퍼 메서드
+    private List<String> createDistanceOptions() {
+        return List.of("가까운 곳으로", "2~3시간 거리", "비행기 타고 멀리");
+    }
+}

--- a/src/main/java/com/compass/domain/chat/model/dto/DestinationRecommendationDto.java
+++ b/src/main/java/com/compass/domain/chat/model/dto/DestinationRecommendationDto.java
@@ -1,0 +1,28 @@
+package com.compass.domain.chat.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+import java.util.List;
+
+
+// 목적지 추천 결과를 담는 DTO.
+// Record 타입을 사용하여 불변 객체로 설계.
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DestinationRecommendationDto(
+        String title,
+        String description,
+        List<String> distanceOptions,
+        List<RecommendedDestination> recommendedDestinations
+) {
+
+    // 개별 추천 목적지 정보를 담는 내부 Record.
+    public record RecommendedDestination(
+            String cityName,
+            String country,
+            String description,
+            String imageUrl,
+            List<String> tags
+    ) {}
+}


### PR DESCRIPTION
# Pull Request

## 작업 정보

### 작업 유형
- [x] 새로운 기능 (New Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 테스트 추가 (Test)
- [ ] 설정 변경 (Configuration)
- [ ] 기타 (Other)

### 관련 이슈
- Issue #203 : Task 2.3.1: RecommendDestinationsFunction.java 구현

### 작업 단위
- [ ] Epic (2-4주)
- [ ] Story (1-2일)
- [x] Task (2-4시간)
- [ ] Sub-task (30분-2시간)

## 변경 사항

### 작업 내용
- `RecommendDestinationsFunction` 클래스 및 응답 DTO `DestinationRecommendationDto` 신규 구현
- 사용자가 "목적지 미정"을 선택했을 경우, `PerplexityClient`를 사용하여 맞춤형 여행지를 추천하는 로직 구현
- 사용자의 출발지, 여행 스타일을 바탕으로 Perplexity API에 전송할 동적 프롬프트 생성
- API 호출 실패 시, 안정성을 위해 빈 추천 목록을 반환하는 예외 처리 로직 포함

### 구현 상세
**위치**:
- `src/main/java/com/compass/domain/chat/function/planning/RecommendDestinationsFunction.java` (신규)
- `src/main/java/com/compass/domain/chat/model/dto/DestinationRecommendationDto.java` (신규)

**목적**: 사용자가 목적지를 정하지 못했을 때, 대화의 맥락(출발지, 스타일 등)을 활용하여 개인화된 목적지를 추천함으로써 사용자 경험을 향상시킵니다.

**의존성**: `PerplexityClient`, `ObjectMapper`

**사용처**: `ChatOrchestrator`가 사용자가 목적지를 입력하지 않았다고 판단했을 때 이 Function을 호출합니다.

**영향범위**: 목적지 추천 시스템의 핵심 기능을 담당합니다. 신규 파일이므로 기존 코드에 영향 없음.

## 체크리스트

### PR 규칙 준수
- [x] **최대 300줄**
- [x] **단일 책임** (한 PR = 한 가지 기능/수정)
- [x] **독립성** (개별 테스트 및 롤백 가능)

### Java 17 & Lombok 사용
- [x] DTO는 Record 사용
- [x] Entity는 Lombok 사용 (`@Slf4j`)
- [x] Service는 @RequiredArgsConstructor
- [ ] var는 타입 명확할 때만 사용
- [ ] Switch Expression 활용
- [ ] Text Block 활용

### 코드 품질
- [x] 메서드 20줄 이내
- [x] 클래스 200줄 이내
- [x] 단일 책임 원칙 준수 (API 호출은 `PerplexityClient`에 위임)
- [ ] Optional 활용

### 주석 규칙
- [x] `//` 주석만 사용
- [x] 한국어로 작성
- [x] 불필요한 주석 제거
- [x] 코드가 명확하면 주석 생략

### 일관성
- [x] 기존 코드 패턴 준수
- [x] 팀 네이밍 컨벤션 준수
- [x] 점진적 개선

### 테스트
- [ ] 단위 테스트 작성 (다음 PR에서 Mockito를 사용한 테스트 추가 예정)
- [ ] 통합 테스트 작성
- [ ] 모든 테스트 통과

### 문서화
- [ ] README 업데이트
- [ ] API 문서 업데이트
- [x] 주요 변경사항 문서화 (본 PR)

## 주요 구현 내용

### 1. 핵심 로직: `RecommendDestinationsFunction`
`PerplexityClient`를 사용하여 API 호출을 위임하고, 프롬프트 생성 및 결과 포장에만 집중합니다.


### 2. 데이터 구조: `DestinationRecommendationDto`
`record`를 사용하여 불변성과 코드 간결성을 확보한 DTO를 정의했습니다.

## 리뷰어에게
- 팀원이 구현한 `PerplexityClient`를 활용하여 목적지 추천 기능을 구현했습니다.
- `RecommendDestinationsFunction`은 프롬프트 생성과 결과 포장의 책임만 가지며, 실제 API 통신 및 응답 파싱의 책임은 `PerplexityClient`에 위임하여 단일 책임 원칙을 준수했습니다.
- 외부 API 호출 실패에 대비하여 `try-catch` 블록으로 예외를 처리하고, 실패 시 빈 목록을 반환하도록 안정성을 확보했습니다.
- 설계의 적절성과 프롬프트 내용에 대해 리뷰 부탁드립니다.

## 배포 고려사항
- `PerplexityClient`가 사용하는 `PERPLEXITY_API_KEY` 환경 변수가 배포 환경에 설정되어야 합니다.

## 다음 작업 예정
1. `RecommendDestinationsFunction`에 대한 단위 테스트 작성



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added destination recommendations that suggest options based on your departure location and travel styles.
  - Each set includes a clear title, description, and three distance options (nearby, 2–3 hours, fly far).
  - Recommendations include city details, reasons to visit, representative images, and helpful tags.
  - Graceful fallback ensures the app remains stable if recommendations cannot be generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->