### PR TITLE
feat: 2.2.2 검증 인터페이스 추가

### DIFF
--- a/src/main/java/com/compass/domain/collection/service/validator/DefaultTravelInfoValidator.java
+++ b/src/main/java/com/compass/domain/collection/service/validator/DefaultTravelInfoValidator.java
@@ -1,0 +1,38 @@
+package com.compass.domain.collection.service.validator;
+
+import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// ValidationRule들을 모아 실행하는 기본 검증기
+@Component
+@RequiredArgsConstructor
+public class DefaultTravelInfoValidator implements TravelInfoValidator {
+
+    // Spring이 등록된 모든 ValidationRule Bean을 주입
+    private final List<ValidationRule> rules;
+    private final List<String> errors = new ArrayList<>();
+
+    @Override
+    public void validate(TravelFormSubmitRequest info) {
+        errors.clear();
+
+        // 주입된 모든 규칙들을 순회하며 검증
+        for (var rule : rules) {
+            try {
+                rule.apply(info);
+            } catch (IllegalArgumentException e) {
+                // 규칙 위반 시, 오류 메시지를 리스트에 추가
+                errors.add(e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public List<String> getErrors() {
+        return new ArrayList<>(errors);
+    }
+}

--- a/src/main/java/com/compass/domain/collection/service/validator/TravelInfoValidator.java
+++ b/src/main/java/com/compass/domain/collection/service/validator/TravelInfoValidator.java
@@ -1,0 +1,14 @@
+package com.compass.domain.collection.service.validator;
+
+import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
+import java.util.List;
+
+// 수집된 여행 정보의 유효성을 검증하는 인터페이스
+public interface TravelInfoValidator {
+
+    // 여행 정보의 유효성을 검증
+    void validate(TravelFormSubmitRequest info);
+
+    // 검증 실패 시 상세 오류 메시지 목록을 반환
+    List<String> getErrors();
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 작업 정보

### 작업 유형
- [x] 새로운 기능 (New Feature)  
- [ ] 버그 수정 (Bug Fix)  
- [ ] 리팩토링 (Refactoring)  
- [ ] 문서 작업 (Documentation)  
- [ ] 테스트 추가 (Test)  
- [ ] 설정 변경 (Configuration)  
- [ ] 기타 (Other)  

---

## 관련 이슈
- Issue #220  : Task 2.2.2: TravelInfoValidator 인터페이스 및 구현체 구현  
  *(이슈 번호는 실제 생성된 번호로 수정해주세요)*  

---

## 작업 단위
- [ ] Epic (2-4주)  
- [ ] Story (1-2일)  
- [x] Task (2-4시간)  
- [ ] Sub-task (30분-2시간)  

---

## 변경 사항

### 작업 내용
- 정보 검증의 실행 책임을 담당하는 `TravelInfoValidator` 인터페이스를 신규 구현했습니다.  
- 사전에 정의된 `ValidationRule`들을 주입받아 순차적으로 실행하는 `DefaultTravelInfoValidator`를 구현하여 **'규칙 체인' 패턴**을 완성했습니다.  
- 개별 규칙에서 발생한 모든 검증 실패 메시지를 수집하여 `getErrors()`를 통해 한 번에 반환하는 로직을 포함했습니다.  

---

## 구현 상세

- **위치:**  
  - `src/main/java/com/compass/domain/collection/service/validator/TravelInfoValidator.java` (신규)  
  - `src/main/java/com/compass/domain/collection/service/validator/DefaultTravelInfoValidator.java` (신규)  

- **목적:**  
  여러 검증 규칙들을 일관된 방식으로 실행하고 관리하는 중앙 창구를 마련하여, 검증 로직의 복잡도를 낮추고 재사용성을 높입니다.  

- **의존성:**  
  `ValidationRule` 인터페이스  

- **사용처:**  
  `SubmitTravelFormFunction` 등 사용자의 입력을 받아 검증이 필요한 모든 곳에서 이 `TravelInfoValidator`를 주입받아 사용할 예정입니다.  

- **영향범위:**  
  신규 파일이므로 기존 코드에 영향 없음.  

---

## 체크리스트

### PR 규칙 준수
- [x] 최대 300줄  
- [x] 단일 책임 (한 PR = Validator 인터페이스 및 기본 구현)  
- [x] 독립성 (개별 테스트 가능)  

### Java 17 & Lombok 사용
- [x] DTO는 Record 사용 (의존하는 DTO가 Record임)  
- [x] Entity는 Lombok 사용  
- [x] Service는 @RequiredArgsConstructor  
- [x] var는 타입 명확할 때만 사용 (`for (var rule : rules)`)  
- [ ] Switch Expression 활용 (해당 없음)  
- [ ] Text Block 활용 (해당 없음)  

### 코드 품질
- [x] 메서드 20줄 이내  
- [x] 클래스 200줄 이내  
- [x] 단일 책임 원칙 준수 (규칙 '실행'의 책임만 가짐)  
- [ ] Optional 활용 (해당 없음)  

### 주석 규칙
- [x] `//` 주석만 사용  
- [x] 한국어로 작성  
- [x] 불필요한 주석 제거  
- [x] 코드가 명확하면 주석 생략  

### 일관성
- [x] 기존 코드 패턴 준수  
- [x] 팀 네이밍 컨벤션 준수  
- [x] 점진적 개선  

---

## 테스트
- [ ] 단위 테스트 작성 (다음 PR에서 Mockito를 사용하여 `ValidationRule`을 Mocking한 테스트 추가 예정)  
- [ ] 통합 테스트 작성  
- [ ] 모든 테스트 통과  

---

## 문서화
- [ ] README 업데이트  
- [ ] API 문서 업데이트  
- [x] 주요 변경사항 문서화 (본 PR)  

---

## 주요 구현 내용

1. **TravelInfoValidator 인터페이스**  
   - `validate()`와 `getErrors()` 메서드를 통해 **검증 실행과 결과 조회의 역할을 명확히 분리**했습니다.  

2. **DefaultTravelInfoValidator 구현체**  
   - Spring의 DI를 통해 `List<ValidationRule>`을 주입받아, 어떤 규칙들이 있는지 알 필요 없이 모든 규칙을 동적으로 실행합니다.  
   - 새로운 규칙이 추가되어도 이 클래스는 수정할 필요가 없습니다. (**OCP**)  

---

## 리뷰어에게
- Task 2.2.7에서 구현한 `ValidationRule`들을 실제로 사용하는 Validator를 구현했습니다.  
- `try-catch`를 사용하여 하나의 규칙이 실패하더라도 모든 규칙을 끝까지 실행하고, 모든 오류 메시지를 수집하여 반환하도록 설계했습니다.  
  - 이 설계가 맞을지 리뷰 부탁드립니다. *(대안: 첫 실패 시 즉시 중단)*  
- `getErrors()`가 `new ArrayList<>(errors)`를 반환하도록 하여 외부에서 내부 `errors` 리스트를 직접 수정할 수 없도록 **방어적 복사**를 적용했습니다.  

---

## 배포 고려사항
- 없음  

---

## 다음 작업 예정
- `FollowUpStrategy` 인터페이스 및 구현체 생성 (Task 2.2.4)  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consistent, comprehensive validation for travel information submissions.
  * Failed submissions now return a clear, consolidated list of specific error messages, helping you fix all issues in one go.
  * Improved user feedback reduces back-and-forth by showing all validation problems at once instead of one-by-one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->