### PR TITLE
feat:Follow-up 프로세스 조정 기능 추가

### DIFF
--- a/src/main/java/com/compass/domain/chat/collection/service/FollowUpOrchestrator.java
+++ b/src/main/java/com/compass/domain/chat/collection/service/FollowUpOrchestrator.java
@@ -1,0 +1,28 @@
+package com.compass.domain.chat.collection.service;
+
+import com.compass.domain.chat.collection.service.strategy.FollowUpStrategy;
+import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+// Follow-up 프로세스를 조정하는 오케스트레이터
+@Service
+@RequiredArgsConstructor
+public class FollowUpOrchestrator {
+
+    // Spring이 등록된 모든 FollowUpStrategy Bean을 주입받아 우선순위대로 사용
+    private final List<FollowUpStrategy> strategies;
+
+    // 다음에 할 Follow-up 질문을 결정하여 반환
+    public Optional<String> determineNextQuestion(TravelFormSubmitRequest currentInfo) {
+        // 주입된 전략들을 순서대로 실행하여 첫 번째로 발견되는 질문을 반환
+        return strategies.stream()
+                .map(strategy -> strategy.findNextQuestion(currentInfo))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+    }
+}

--- a/src/test/java/com/compass/domain/chat/collection/service/FollowUpOrchestratorTest.java
+++ b/src/test/java/com/compass/domain/chat/collection/service/FollowUpOrchestratorTest.java
@@ -1,0 +1,88 @@
+package com.compass.domain.chat.collection.service;
+
+import com.compass.domain.chat.collection.service.strategy.ClarificationStrategy;
+import com.compass.domain.chat.collection.service.strategy.MissingFieldStrategy;
+import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FollowUpOrchestratorTest {
+
+    @Mock
+    private MissingFieldStrategy missingFieldStrategy;
+    @Mock
+    private ClarificationStrategy clarificationStrategy;
+
+    private FollowUpOrchestrator orchestrator;
+
+    @BeforeEach
+    void setUp() {
+        // 전략의 순서가 중요: 누락 필드 확인 -> 모호한 정보 확인
+        orchestrator = new FollowUpOrchestrator(List.of(missingFieldStrategy, clarificationStrategy));
+    }
+
+    @Test
+    @DisplayName("첫 번째 전략(MissingField)이 질문을 찾으면, 그 질문을 즉시 반환하고 다음 전략은 실행하지 않는다")
+    void determineNextQuestion_shouldReturnFirstQuestion_whenFirstStrategyFindsOne() {
+        // given
+        var info = new TravelFormSubmitRequest(null, null, null, null, null, null, null, null);
+        String missingFieldQuestion = "목적지가 어디인가요?";
+
+        when(missingFieldStrategy.findNextQuestion(info)).thenReturn(Optional.of(missingFieldQuestion));
+        // clarificationStrategy.findNextQuestion()는 호출되지 않아야 함
+
+        // when
+        Optional<String> result = orchestrator.determineNextQuestion(info);
+
+        // then
+        assertThat(result).isPresent().contains(missingFieldQuestion);
+        verify(missingFieldStrategy, times(1)).findNextQuestion(info);
+        verify(clarificationStrategy, never()).findNextQuestion(info); // 두 번째 전략은 호출되지 않음
+    }
+
+    @Test
+    @DisplayName("첫 번째 전략이 질문을 못 찾으면, 두 번째 전략(Clarification)을 실행하여 질문을 찾는다")
+    void determineNextQuestion_shouldUseSecondStrategy_whenFirstFindsNothing() {
+        // given
+        var info = new TravelFormSubmitRequest(null, null, null, null, null, null, null, null);
+        String clarificationQuestion = "목적지를 더 구체적으로 알려주세요.";
+
+        when(missingFieldStrategy.findNextQuestion(info)).thenReturn(Optional.empty());
+        when(clarificationStrategy.findNextQuestion(info)).thenReturn(Optional.of(clarificationQuestion));
+
+        // when
+        Optional<String> result = orchestrator.determineNextQuestion(info);
+
+        // then
+        assertThat(result).isPresent().contains(clarificationQuestion);
+        verify(missingFieldStrategy, times(1)).findNextQuestion(info);
+        verify(clarificationStrategy, times(1)).findNextQuestion(info);
+    }
+
+    @Test
+    @DisplayName("모든 전략이 질문을 찾지 못하면, 비어있는 Optional을 반환한다")
+    void determineNextQuestion_shouldReturnEmpty_whenNoStrategyFindsQuestion() {
+        // given
+        var info = new TravelFormSubmitRequest(null, null, null, null, null, null, null, null);
+
+        when(missingFieldStrategy.findNextQuestion(info)).thenReturn(Optional.empty());
+        when(clarificationStrategy.findNextQuestion(info)).thenReturn(Optional.empty());
+
+        // when
+        Optional<String> result = orchestrator.determineNextQuestion(info);
+
+        // then
+        assertThat(result).isNotPresent();
+    }
+}


### PR DESCRIPTION
Closes #243 

## 📌 개요
- **Epic**: CHAT2 여행 정보 수집 시스템
- **Story**: S2.3. 구현체 및 서비스 계층
- **Task**: T2.3.10. FollowUpOrchestrator 구현
- **예상 소요시간**: 2시간
- **실제 소요시간**: 1.5시간

## 🎯 구현 목적
### 전체 시스템에서의 역할
- Follow-up 질문 생성을 위한 **'의사결정자'** 역할을 합니다. "필수 정보가 빠졌는가?"를 먼저 확인(`MissingFieldStrategy`)하고, 다 채워졌다면 "혹시 정보가 애매하지는 않은가?"를 확인(`ClarificationStrategy`)하는 식으로 질문의 우선순위를 관리합니다.

### 이 코드가 필요한 이유
- **기존:** 질문 생성 로직이 단일 클래스에 복잡하게 얽혀 있었습니다.
- **개선:** `FollowUpOrchestrator`가 여러 질문 전략(`FollowUpStrategy`)을 조율하는 중앙 지휘자 역할을 합니다.
- **효과:** 질문 생성 로직이 체계화되고, 향후 "여행 스타일 기반 추천 질문 전략"과 같은 새로운 전략을 추가할 때 기존 코드를 수정하지 않고 확장할 수 있어 유지보수성이 향상됩니다 (OCP).

## 🏗️ 설계 결정 사항
### 왜 이런 구조를 선택했는가?
1. **전략 패턴(Strategy Pattern) 활용**
   - **이유:** 질문을 생성하는 다양한 방법(전략)을 캡슐화하고, 런타임에 어떤 전략을 사용할지 선택할 수 있게 하기 위함입니다.
   - **장점:** `MissingFieldStrategy`, `ClarificationStrategy` 등 새로운 질문 전략을 추가하거나 순서를 변경하는 것이 매우 유연합니다.

2. **Spring의 자동 List 주입 기능 활용**
   - **이유:** `@Autowired private final List<FollowUpStrategy> strategies;`와 같이 선언하면, Spring이 `FollowUpStrategy` 타입의 모든 Bean을 찾아 자동으로 리스트에 주입해줍니다. `@Order` 어노테이션을 통해 주입 순서(즉, 실행 우선순위)를 제어할 수 있습니다.
   - **장점:** 새로운 전략을 추가할 때 `FollowUpOrchestrator` 코드를 변경할 필요 없이, 새 전략 클래스에 `@Component`와 `@Order`만 추가하면 되므로 확장성이 뛰어납니다.

## ✅ 구현 내용
### 주요 변경사항
- **`FollowUpOrchestrator.java` 신규 구현**:
    - 주입된 `FollowUpStrategy` 리스트를 순회하며 `findNextQuestion`을 호출하고, 가장 먼저 유효한 질문을 찾아 반환하는 로직을 구현했습니다.
- **`FollowUpOrchestratorTest.java` 신규 작성**:
    - Mock 전략들을 사용하여 오케스트레이터의 우선순위 로직(short-circuiting)을 검증하는 테스트를 추가했습니다.

## 🔗 의존성 및 영향 범위
### 사용하는 컴포넌트
- `FollowUpStrategy`: 질문 생성 전략 인터페이스

### 이 코드를 사용하는 곳
- `TravelInfoCollectionService`: `collectInfo` 파이프라인의 마지막 단계에서 다음 질문을 결정하기 위해 이 클래스를 호출합니다.

### 영향 범위
- 신규 기능으로, `TravelInfoCollectionService`에 해당 클래스의 의존성이 추가됩니다.

## 🧪 테스트
### 테스트 시나리오
- [x] `MissingFieldStrategy`가 질문을 반환할 때, `ClarificationStrategy`는 호출되지 않는지 확인
- [x] `MissingFieldStrategy`가 빈 Optional을 반환할 때, `ClarificationStrategy`가 호출되는지 확인
- [x] 모든 전략이 질문을 찾지 못할 때, 비어있는 `Optional`이 반환되는지 확인

### 테스트 결과
- 테스트 통과: 3/3
- 코드 커버리지: 100%