### PR TITLE
feat: 수집기 생성 팩토리 기능 추가

### DIFF
--- a/src/main/java/com/compass/domain/chat/collection/service/CollectorFactory.java
+++ b/src/main/java/com/compass/domain/chat/collection/service/CollectorFactory.java
@@ -1,0 +1,25 @@
+package com.compass.domain.chat.collection.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+// 사용자 선택에 따라 적절한 정보 수집기(Collector)를 생성하는 팩토리
+@Component
+@RequiredArgsConstructor
+public class CollectorFactory {
+
+    // Spring이 Bean 이름을 key로 하여 모든 TravelInfoCollector 구현체를 주입
+    private final Map<String, TravelInfoCollector> collectors;
+
+    public TravelInfoCollector getCollector(String type) {
+        String beanName = type + "BasedCollector"; // "form" -> "formBasedCollector"
+        TravelInfoCollector collector = collectors.get(beanName);
+
+        if (collector == null) {
+            throw new IllegalArgumentException("지원하지 않는 수집기 타입입니다: " + type);
+        }
+        return collector;
+    }
+}

--- a/src/test/java/com/compass/domain/chat/collection/service/CollectorFactoryTest.java
+++ b/src/test/java/com/compass/domain/chat/collection/service/CollectorFactoryTest.java
@@ -1,0 +1,61 @@
+package com.compass.domain.chat.collection.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+class CollectorFactoryTest {
+
+    @Mock
+    private FormBasedCollector formBasedCollector;
+    @Mock
+    private ConversationBasedCollector conversationBasedCollector;
+
+    private CollectorFactory collectorFactory;
+
+    @BeforeEach
+    void setUp() {
+        // 실제 Spring의 동작을 모방하여 Bean 이름과 객체를 매핑
+        Map<String, TravelInfoCollector> collectors = Map.of(
+                "formBasedCollector", formBasedCollector,
+                "conversationBasedCollector", conversationBasedCollector
+        );
+        collectorFactory = new CollectorFactory(collectors);
+    }
+
+    @Test
+    @DisplayName("getCollector - 'form' 타입이 주어지면 FormBasedCollector를 반환한다")
+    void getCollector_shouldReturnFormBasedCollector_forTypeForm() {
+        // when
+        TravelInfoCollector collector = collectorFactory.getCollector("form");
+        // then
+        assertThat(collector).isInstanceOf(FormBasedCollector.class);
+    }
+
+    @Test
+    @DisplayName("getCollector - 'conversation' 타입이 주어지면 ConversationBasedCollector를 반환한다")
+    void getCollector_shouldReturnConversationBasedCollector_forTypeConversation() {
+        // when
+        TravelInfoCollector collector = collectorFactory.getCollector("conversation");
+        // then
+        assertThat(collector).isInstanceOf(ConversationBasedCollector.class);
+    }
+
+    @Test
+    @DisplayName("getCollector - 지원하지 않는 타입이 주어지면 예외를 발생시킨다")
+    void getCollector_shouldThrowException_forUnsupportedType() {
+        // when & then
+        assertThatThrownBy(() -> collectorFactory.getCollector("unsupported"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("지원하지 않는 수집기 타입입니다: unsupported");
+    }
+}


### PR DESCRIPTION
Closes #245 

## 📌 개요
- **Epic**: CHAT2 여행 정보 수집 시스템
- **Story**: S2.3. 구현체 및 서비스 계층
- **Task**: T2.3.12. CollectorFactory 구현
- **예상 소요시간**: 2시간
- **실제 소요시간**: 1.5시간

## 🎯 구현 목적
### 전체 시스템에서의 역할
- 정보 수집 방식을 결정하는 **'분류 담당자'** 역할을 합니다. `TravelInfoCollectionService`는 이 팩토리를 통해 "지금은 폼 데이터를 처리할 차례이니 `FormBasedCollector`를 주세요" 또는 "이제부터는 대화로 정보를 수집해야 하니 `ConversationBasedCollector`를 주세요" 와 같이 상황에 맞는 도구(Collector)를 공급받습니다.

### 이 코드가 필요한 이유
- **기존:** `TravelInfoCollectionService` 내부에 `if/else` 분기문으로 Collector를 선택하는 로직이 있어 확장성이 떨어졌습니다.
- **개선:** Collector를 생성하고 선택하는 책임을 `CollectorFactory`로 분리했습니다.
- **효과:** 정보 수집 방식(폼/대화)에 따른 처리 로직을 서비스 코드로부터 분리하고, 향후 "이미지 기반 수집기"와 같은 새로운 수집 방식이 추가되더라도 `TravelInfoCollectionService`의 변경 없이 팩토리에만 추가하면 되도록 시스템을 유연하게 만듭니다 (OCP).

## 🏗️ 설계 결정 사항
### 왜 이런 구조를 선택했는가?
1. **팩토리 메서드 패턴(Factory Method Pattern) 적용**
   - **이유:** 객체 생성 로직을 캡슐화하여, 클라이언트(`TravelInfoCollectionService`)가 구체적인 Collector 클래스에 직접 의존하지 않도록 하기 위함입니다.
   - **장점:** 새로운 Collector가 추가되어도 `TravelInfoCollectionService`는 수정할 필요가 없으므로 시스템의 확장성과 유지보수성이 향상됩니다.

2. **Spring의 `Map` 기반 Bean 주입 활용**
   - **이유:** Spring이 컨테이너에 있는 모든 `TravelInfoCollector` 타입의 Bean을 자동으로 `Map<String, TravelInfoCollector>` 형태로 주입해주는 기능을 활용했습니다. (`String`은 Bean의 이름)
   - **장점:** 새로운 Collector를 추가할 때 팩토리 코드를 수정할 필요 없이, 새 클래스에 `@Component("newBasedCollector")` 어노테이션만 붙이면 자동으로 팩토리에 등록됩니다.

## ✅ 구현 내용
### 주요 변경사항
- **`CollectorFactory.java` 신규 구현**:
    - 주입된 `Map`에서 요청 타입에 맞는 `TravelInfoCollector` Bean을 찾아 반환하는 `getCollector` 메서드를 구현했습니다.
    - 지원하지 않는 타입에 대한 `IllegalArgumentException` 처리 로직을 추가했습니다.
- **`CollectorFactoryTest.java` 신규 작성**:
    - Mock Collector들을 사용하여 팩토리의 분기 로직과 예외 처리 로직을 검증하는 테스트를 추가했습니다.

## 🔗 의존성 및 영향 범위
### 사용하는 컴포넌트
- `TravelInfoCollector`: 정보 수집기 인터페이스

### 이 코드를 사용하는 곳
- `TravelInfoCollectionService`: `collectInfo` 파이프라인 내부에서 적절한 Collector를 얻기 위해 이 팩토리를 호출합니다.

### 영향 범위
- 신규 기능으로, `TravelInfoCollectionService`에 해당 팩토리의 의존성이 추가됩니다.

## 🧪 테스트
### 테스트 시나리오
- [x] `getCollector("form")` 호출 시 `FormBasedCollector` 반환 확인
- [x] `getCollector("conversation")` 호출 시 `ConversationBasedCollector` 반환 확인
- [x] `getCollector("unsupported")` 호출 시 `IllegalArgumentException` 발생 확인

### 테스트 결과
- 테스트 통과: 3/3
- 코드 커버리지: 100%