### PR TITLE
feat: 전략 생성 팩토리 기능 추가

### DIFF
--- a/src/main/java/com/compass/domain/chat/collection/service/StrategyFactory.java
+++ b/src/main/java/com/compass/domain/chat/collection/service/StrategyFactory.java
@@ -1,0 +1,32 @@
+package com.compass.domain.chat.collection.service;
+
+import com.compass.domain.chat.collection.service.strategy.ClarificationStrategy;
+import com.compass.domain.chat.collection.service.strategy.FollowUpStrategy;
+import com.compass.domain.chat.collection.service.strategy.MissingFieldStrategy;
+import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.util.Optional;
+
+// 컨텍스트를 분석하여 적절한 Follow-up 전략을 생성하는 팩토리
+@Component
+@RequiredArgsConstructor
+public class StrategyFactory {
+
+    private final MissingFieldStrategy missingFieldStrategy;
+    private final ClarificationStrategy clarificationStrategy;
+
+    // 현재 정보에 가장 적합한 전략을 찾아 반환
+    public Optional<FollowUpStrategy> getStrategy(TravelFormSubmitRequest info) {
+        // 우선순위 1: 필수 정보 누락 확인
+        if (missingFieldStrategy.findNextQuestion(info).isPresent()) {
+            return Optional.of(missingFieldStrategy);
+        }
+        // 우선순위 2: 정보 명확화 필요 확인
+        if (clarificationStrategy.findNextQuestion(info).isPresent()) {
+            return Optional.of(clarificationStrategy);
+        }
+        // 적용할 전략이 없음
+        return Optional.empty();
+    }
+}

--- a/src/test/java/com/compass/domain/chat/collection/service/StrategyFactoryTest.java
+++ b/src/test/java/com/compass/domain/chat/collection/service/StrategyFactoryTest.java
@@ -1,0 +1,73 @@
+package com.compass.domain.chat.collection.service;
+
+import com.compass.domain.chat.collection.service.strategy.ClarificationStrategy;
+import com.compass.domain.chat.collection.service.strategy.FollowUpStrategy;
+import com.compass.domain.chat.collection.service.strategy.MissingFieldStrategy;
+import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StrategyFactoryTest {
+
+    @Mock
+    private MissingFieldStrategy missingFieldStrategy;
+    @Mock
+    private ClarificationStrategy clarificationStrategy;
+
+    @InjectMocks
+    private StrategyFactory strategyFactory;
+
+    @Test
+    @DisplayName("getStrategy - 필수 정보가 누락되면 MissingFieldStrategy를 반환한다")
+    void getStrategy_shouldReturnMissingFieldStrategy_whenFieldsAreMissing() {
+        // given
+        var info = new TravelFormSubmitRequest(null, null, null, null, null, null, null, null);
+        when(missingFieldStrategy.findNextQuestion(info)).thenReturn(Optional.of("목적지 질문"));
+
+        // when
+        Optional<FollowUpStrategy> strategy = strategyFactory.getStrategy(info);
+
+        // then
+        assertThat(strategy).isPresent().contains(missingFieldStrategy);
+    }
+
+    @Test
+    @DisplayName("getStrategy - 필수 정보는 있지만 정보가 모호하면 ClarificationStrategy를 반환한다")
+    void getStrategy_shouldReturnClarificationStrategy_whenInfoIsAmbiguous() {
+        // given
+        var info = new TravelFormSubmitRequest(null, null, null, null, null, null, null, null);
+        when(missingFieldStrategy.findNextQuestion(info)).thenReturn(Optional.empty());
+        when(clarificationStrategy.findNextQuestion(info)).thenReturn(Optional.of("목적지 구체화 질문"));
+
+        // when
+        Optional<FollowUpStrategy> strategy = strategyFactory.getStrategy(info);
+
+        // then
+        assertThat(strategy).isPresent().contains(clarificationStrategy);
+    }
+
+    @Test
+    @DisplayName("getStrategy - 적용할 전략이 없으면 비어있는 Optional을 반환한다")
+    void getStrategy_shouldReturnEmpty_whenNoStrategyIsApplicable() {
+        // given
+        var info = new TravelFormSubmitRequest(null, null, null, null, null, null, null, null);
+        when(missingFieldStrategy.findNextQuestion(info)).thenReturn(Optional.empty());
+        when(clarificationStrategy.findNextQuestion(info)).thenReturn(Optional.empty());
+
+        // when
+        Optional<FollowUpStrategy> strategy = strategyFactory.getStrategy(info);
+
+        // then
+        assertThat(strategy).isNotPresent();
+    }
+}


### PR DESCRIPTION
Closes #246 

## 📌 개요
- **Epic**: CHAT2 여행 정보 수집 시스템
- **Story**: S2.3. 구현체 및 서비스 계층
- **Task**: T2.3.13. StrategyFactory 구현
- **예상 소요시간**: 2시간
- **실제 소요시간**: 1.5시간

## 🎯 구현 목적
### 전체 시스템에서의 역할
- Follow-up 질문의 **'전략 분석가'** 역할을 합니다. 현재 정보 상태를 진단하고, "지금은 필수 정보부터 물어봐야 할 때입니다 (`MissingFieldStrategy` 사용)" 또는 "정보는 다 있지만, 답변이 애매하니 구체적으로 물어봅시다 (`ClarificationStrategy` 사용)" 와 같이 가장 효과적인 질문 전략을 추천합니다.

### 이 코드가 필요한 이유
- **기존:** `FollowUpOrchestrator`가 전략 선택과 실행이라는 두 가지 책임을 모두 가지고 있었습니다.
- **개선:** 전략을 **선택**하는 책임을 `StrategyFactory`로 분리했습니다.
- **효과:** `FollowUpOrchestrator`는 단순히 전략을 실행하는 역할에만 집중할 수 있게 되며, 전략을 선택하는 복잡한 로직이 팩토리로 분리되어 코드의 단일 책임 원칙(SRP)을 강화하고, 각 컴포넌트의 역할을 명확하게 만듭니다.

## 🏗️ 설계 결정 사항
### 왜 이런 구조를 선택했는가?
1. **팩토리 메서드 패턴(Factory Method Pattern) 적용**
   - **이유:** 객체(전략) 생성 로직을 캡슐화하고, 클라이언트(`FollowUpOrchestrator`)가 어떤 전략을 사용해야 할지 결정하는 복잡한 로직으로부터 분리하기 위함입니다.
   - **장점:** 전략 선택 로직이 변경되더라도 `FollowUpOrchestrator`는 수정할 필요가 없어 시스템의 유연성이 높아집니다.

2. **우선순위 기반 로직**
   - **이유:** 사용자 경험상, 필수 정보가 누락된 것을 먼저 묻는 것이 정보가 모호한 것을 묻는 것보다 더 중요하기 때문입니다.
   - **장점:** 체계적이고 논리적인 순서로 질문을 생성하여, 더 자연스러운 대화 흐름을 유도할 수 있습니다.

## ✅ 구현 내용
### 주요 변경사항
- **`StrategyFactory.java` 신규 구현**:
    - 정보 상태를 분석하여 우선순위(`MissingFieldStrategy` → `ClarificationStrategy`)에 따라 `FollowUpStrategy`를 선택하는 `getStrategy` 메서드를 구현했습니다.
- **`StrategyFactoryTest.java` 신규 작성**:
    - Mock 전략들의 `findNextQuestion` 반환 값을 조작하여, 팩토리의 우선순위 기반 선택 로직을 정밀하게 검증하는 테스트를 추가했습니다.

## 🔗 의존성 및 영향 범위
### 사용하는 컴포넌트
- `MissingFieldStrategy`, `ClarificationStrategy`: 어떤 전략을 선택할지 결정하기 위해 사용됩니다.

### 이 코드를 사용하는 곳
- `FollowUpOrchestrator`: 어떤 전략을 실행할지 결정하기 위해 이 팩토리를 호출할 수 있습니다. (리팩토링 예정)

### 영향 범위
- 신규 기능으로, 향후 `FollowUpOrchestrator`가 이 팩토리를 사용하도록 리팩토링될 예정입니다.

## 🧪 테스트
### 테스트 시나리오
- [x] `missingFieldStrategy.findNextQuestion()`이 질문을 반환할 때, 팩토리가 `MissingFieldStrategy`를 반환하는지 확인
- [x] `missingFieldStrategy`는 빈 Optional을 반환하지만 `clarificationStrategy`가 질문을 반환할 때, 팩토리가 `ClarificationStrategy`를 반환하는지 확인
- [x] 모든 전략이 질문을 찾지 못할 때, 비어있는 `Optional`이 반환되는지 확인

### 테스트 결과
- 테스트 통과: 3/3
- 코드 커버리지: 100%