### PR TITLE
docs: 정보수집 핵심 Function 코드 리팩토링

### DIFF
--- a/src/main/java/com/compass/domain/chat/function/collection/AnalyzeUserInputFunction.java
+++ b/src/main/java/com/compass/domain/chat/function/collection/AnalyzeUserInputFunction.java
@@ -2,13 +2,11 @@ package com.compass.domain.chat.function.collection;
 
 import com.compass.domain.chat.model.request.AnalyzeUserInputRequest;
 import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.compass.domain.chat.parser.service.NaturalLanguageParser; // ◀◀◀ 1. NaturalLanguageParser를 import 합니다.
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
 import java.util.function.Function;
 
 // 사용자의 자연어 입력을 분석하여 여행 정보를 추출하고 업데이트하는 Function
@@ -17,63 +15,12 @@ import java.util.function.Function;
 @RequiredArgsConstructor
 public class AnalyzeUserInputFunction implements Function<AnalyzeUserInputRequest, TravelFormSubmitRequest> {
 
-    private final ChatClient.Builder chatClientBuilder;
-    private final ObjectMapper objectMapper;
-
-    // LLM에게 역할을 지시하는 프롬프트 템플릿
-    private static final String PROMPT_TEMPLATE = """
-            당신은 여행 정보 추출 전문가입니다. 사용자가 제공한 새로운 정보를 바탕으로 기존 JSON 객체를 업데이트하는 것이 당신의 임무입니다.
-            현재 날짜는 {currentDate}입니다. "다음 주 금요일"이나 "이번 주말" 같은 상대적인 날짜를 해석할 때 이 정보를 사용하세요.
-
-            현재까지 수집된 여행 정보는 다음과 같습니다:
-            ---
-            {currentInfo}
-            ---
-            사용자가 방금 다음과 같은 새로운 정보를 입력했습니다: "{userInput}"
-
-            사용자의 입력을 분석하여 현재 여행 정보를 업데이트하세요.
-            - 사용자의 입력에 명확하게 언급된 필드만 업데이트하세요.
-            - 언급되지 않은 정보는 임의로 만들지 마세요.
-            - 사용자의 입력이 불분명하거나 여행 관련 질문에 대한 답변이 아닌 것 같으면, 아무것도 변경하지 말고 원래 정보를 그대로 반환하세요.
-
-            오직 업데이트된 JSON 객체만 응답해야 합니다. JSON 구조는 반드시 다음 형식을 따라야 합니다:
-            {
-              "userId": "string",
-              "destinations": ["string"],
-              "departureLocation": "string",
-              "travelDates": { "startDate": "YYYY-MM-DD", "endDate": "YYYY-MM-DD" },
-              "companions": "string",
-              "budget": 0,
-              "travelStyle": ["string"],
-              "reservationDocument": "string"
-            }
-            """;
+    private final NaturalLanguageParser naturalLanguageParser;
 
     @Override
     public TravelFormSubmitRequest apply(AnalyzeUserInputRequest request) {
-        log.info("사용자 입력 분석을 시작합니다. userId: {}, input: '{}'", request.userId(), request.userInput());
+        log.info("사용자 입력 분석 시작 -> NaturalLanguageParser 위임. userId: {}, input: '{}'", request.userId(), request.userInput());
 
-        try {
-            String currentInfoJson = objectMapper.writeValueAsString(request.currentInfo());
-
-            // 필요할 때마다 ChatClient를 직접 생성해서 사용
-            ChatClient chatClient = chatClientBuilder.build();
-
-            String llmResponse = chatClient.prompt()
-                    .user(p -> p.text(PROMPT_TEMPLATE)
-                            .param("currentDate", LocalDate.now().toString())
-                            .param("currentInfo", currentInfoJson)
-                            .param("userInput", request.userInput()))
-                    .call()
-                    .content(); // LLM의 응답을 순수 문자열로 받음
-
-            // 응답 문자열을 DTO 객체로 직접 파싱
-            return objectMapper.readValue(llmResponse, TravelFormSubmitRequest.class);
-
-        } catch (Exception e) {
-            log.error("LLM 호출 또는 응답 파싱 중 오류 발생. 원본 정보를 반환합니다. userId: {}", request.userId(), e);
-            // 오류 발생 시, 기존 정보를 그대로 반환하여 안정성 확보
-            return request.currentInfo();
-        }
+        return naturalLanguageParser.parse(request.userInput(), request.currentInfo());
     }
 }

--- a/src/main/java/com/compass/domain/chat/function/collection/ContinueFollowUpFunction.java
+++ b/src/main/java/com/compass/domain/chat/function/collection/ContinueFollowUpFunction.java
@@ -1,49 +1,43 @@
 package com.compass.domain.chat.function.collection;
 
-import com.compass.domain.chat.followup.service.FollowUpQuestionSelector;
-import com.compass.domain.chat.model.request.AnalyzeUserInputRequest;
-
-import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
+import com.compass.domain.chat.collection.service.TravelInfoCollectionService;
 import com.compass.domain.chat.model.response.ChatResponse;
 import com.compass.domain.chat.model.response.FollowUpResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-
 import java.util.function.Function;
 
-// Follow-up 대화를 계속 진행할지, 아니면 종료할지를 결정하는 Function
 @Slf4j
 @Component("continueFollowUp")
 @RequiredArgsConstructor
 public class ContinueFollowUpFunction implements Function<FollowUpResponse, ChatResponse> {
 
-    private final AnalyzeUserInputFunction analyzer; // 사용자 입력 분석기
-    private final FollowUpQuestionSelector questionSelector;
+    private final TravelInfoCollectionService collectionService;
 
     @Override
     public ChatResponse apply(FollowUpResponse response) {
-        log.info("Follow-up 응답을 처리하고 대화를 계속합니다. userId: {}", response.currentInfo().userId());
+        log.info("Follow-up 응답 처리 시작: userId={}", response.currentInfo().userId());
 
-        // 1. 사용자 답변을 분석하여 TravelInfo를 업데이트
-        TravelFormSubmitRequest updatedInfo = analyzer.apply(
-            new AnalyzeUserInputRequest(response.currentInfo().userId(), response.userInput(), response.currentInfo())
+        // 정보 수집의 모든 책임을 Service에 위임
+        var result = collectionService.collectInfo(
+                response.currentInfo().userId(), // 실제로는 threadId를 사용해야 할 수 있음
+                response.userInput(),
+                "conversation" // 대화 기반 수집임을 명시
         );
 
-        // 2. 업데이트된 정보로 다음 질문을 찾음 (완성도 재평가)
-        return questionSelector.findNextQuestion(updatedInfo)
-                .map(nextQuestion -> {
-                    // 3-1. 다음 질문이 있으면, 질문을 생성
-                    log.info("다음 Follow-up 질문을 생성합니다: {}", nextQuestion);
+        // 서비스 처리 결과를 바탕으로 응답 생성
+        return result.nextQuestion()
+                .map(question -> {
+                    log.info("다음 Follow-up 질문 생성: {}", question);
                     return ChatResponse.builder()
-                            .content(nextQuestion)
+                            .content(question)
                             .type("ASSISTANT_MESSAGE")
                             .nextAction("AWAIT_USER_INPUT")
                             .build();
                 })
                 .orElseGet(() -> {
-                    // 3-2. 모든 정보가 수집되었으면, Phase 전환
-                    log.info("모든 필수 정보가 수집되었습니다. 여행 계획 생성 단계로 전환합니다. userId: {}", updatedInfo.userId());
+                    log.info("모든 필수 정보 수집 완료. 여행 계획 생성 단계로 전환합니다.");
                     return ChatResponse.builder()
                             .content("감사합니다! 필요한 정보가 모두 모였습니다. 이제 멋진 여행 계획을 세워드릴게요. 잠시만 기다려주세요.")
                             .type("ASSISTANT_MESSAGE")

--- a/src/main/java/com/compass/domain/chat/function/collection/StartFollowUpFunction.java
+++ b/src/main/java/com/compass/domain/chat/function/collection/StartFollowUpFunction.java
@@ -1,35 +1,33 @@
 package com.compass.domain.chat.function.collection;
 
-import com.compass.domain.chat.followup.service.FollowUpQuestionSelector;
+import com.compass.domain.chat.collection.service.FollowUpOrchestrator;
+import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
 import com.compass.domain.chat.model.response.ChatResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-
 import java.util.function.Function;
 
-// Follow-up 질문을 시작하는 Function
-// SubmitTravelFormFunction에서 정보가 불완전하다고 판단했을 때 호출.
 @Slf4j
-@Component("startFollowUp") // nextAction "START_FOLLOW_UP"과 매핑
+@Component("startFollowUp")
 @RequiredArgsConstructor
-public class StartFollowUpFunction implements Function<com.compass.domain.chat.model.request.TravelFormSubmitRequest, ChatResponse> {
+public class StartFollowUpFunction implements Function<TravelFormSubmitRequest, ChatResponse> {
 
-    private final FollowUpQuestionSelector questionSelector;
+    private final FollowUpOrchestrator followUpOrchestrator;
 
     @Override
-    public ChatResponse apply(com.compass.domain.chat.model.request.TravelFormSubmitRequest incompleteInfo) {
-        log.info("Follow-up 질문 생성을 시작합니다.");
+    public ChatResponse apply(TravelFormSubmitRequest incompleteInfo) {
+        log.info("Follow-up 질문 생성 시작");
 
-        // 질문 선택자에게 다음 질문을 찾아달라고 요청
-        String firstQuestion = questionSelector.findNextQuestion(incompleteInfo)
-                .orElse("필요한 정보는 모두 확인된 것 같아요. 이제 여행 계획을 세워볼까요?"); // 방어 코드
-        
-        log.info("첫 Follow-up 질문을 생성합니다: {}", firstQuestion);
+        // 질문 선택 책임을 Orchestrator에 위임
+        String firstQuestion = followUpOrchestrator.determineNextQuestion(incompleteInfo)
+                .orElse("필요한 정보는 모두 확인된 것 같아요. 이제 여행 계획을 세워볼까요?");
+
+        log.info("첫 Follow-up 질문 생성: {}", firstQuestion);
         return ChatResponse.builder()
                 .content(firstQuestion)
                 .type("ASSISTANT_MESSAGE")
-                .nextAction("AWAIT_USER_INPUT") // 사용자의 다음 입력을 기다림
+                .nextAction("AWAIT_USER_INPUT")
                 .build();
     }
 }

--- a/src/main/java/com/compass/domain/chat/function/collection/SubmitTravelFormFunction.java
+++ b/src/main/java/com/compass/domain/chat/function/collection/SubmitTravelFormFunction.java
@@ -1,64 +1,42 @@
 package com.compass.domain.chat.function.collection;
 
+import com.compass.domain.chat.collection.service.validator.DefaultTravelInfoValidator;
 import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
 import com.compass.domain.chat.model.response.ChatResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
-import org.springframework.util.StringUtils;
-
 import java.util.function.Function;
 
-// 빠른 입력 폼 제출을 처리하는 Function
-// 제출된 데이터의 완성도를 검증하고, 다음 단계(Phase)를 결정합니다.
 @Slf4j
 @Component("submitTravelForm")
 @RequiredArgsConstructor
 public class SubmitTravelFormFunction implements Function<TravelFormSubmitRequest, ChatResponse> {
 
+    private final DefaultTravelInfoValidator validator;
+
     @Override
     public ChatResponse apply(TravelFormSubmitRequest request) {
-        log.info("폼 데이터 제출을 처리합니다. userId: {}", request.userId());
-        log.debug("제출된 데이터: {}", request);
+        log.info("폼 데이터 제출 처리 시작: userId={}", request.userId());
 
-        // 필수 정보 완성도 검증
-        if (isFormComplete(request)) {
-            // 정보가 완성된 경우
+        // 검증 책임을 Validator에게 위임
+        validator.validate(request);
+
+        // 검증 결과를 바탕으로 다음 액션 결정
+        if (validator.getErrors().isEmpty()) {
             log.info("필수 정보가 모두 입력되었습니다. 여행 계획 생성 단계로 전환합니다.");
-
-            // 다음 단계 안내 응답 생성
             return ChatResponse.builder()
                     .content("감사합니다! 입력해주신 정보를 바탕으로 멋진 여행 계획을 세워드릴게요. 잠시만 기다려주세요.")
                     .type("ASSISTANT_MESSAGE")
-                    .nextAction("TRIGGER_PLAN_GENERATION") // 오케스트레이터가 이 액션을 보고 계획 생성 Function을 호출
+                    .nextAction("TRIGGER_PLAN_GENERATION")
                     .build();
         } else {
-            // 정보가 불완전한 경우
             log.info("필수 정보가 누락되었습니다. Follow-up 질문 단계로 전환합니다.");
-
-            // Follow-up 시작 안내 응답 생성
             return ChatResponse.builder()
                     .content("입력해주셔서 감사합니다. 몇 가지만 더 여쭤봐도 될까요?")
                     .type("ASSISTANT_MESSAGE")
-                    .nextAction("START_FOLLOW_UP") // 오케스트레이터가 이 액션을 보고 Follow-up Function을 호출
+                    .nextAction("START_FOLLOW_UP")
                     .build();
         }
-    }
-
-    // 폼 데이터 완성도 검증 로직
-    // 필수 필드: 목적지, 출발지, 여행 날짜
-    private boolean isFormComplete(TravelFormSubmitRequest request) {
-        // 1. 목적지 검증 (비어있지 않고, "목적지 미정"이 아닌 경우)
-        boolean isDestinationValid = !CollectionUtils.isEmpty(request.destinations()) &&
-                request.destinations().stream().noneMatch("목적지 미정"::equalsIgnoreCase);
-
-        // 2. 출발지 검증
-        boolean isDepartureValid = StringUtils.hasText(request.departureLocation());
-
-        // 3. 여행 날짜 검증
-        boolean isDatesValid = request.travelDates() != null && request.travelDates().startDate() != null && request.travelDates().endDate() != null;
-
-        return isDestinationValid && isDepartureValid && isDatesValid;
     }
 }

--- a/src/main/java/com/compass/domain/chat/function/config/FunctionConfiguration.java
+++ b/src/main/java/com/compass/domain/chat/function/config/FunctionConfiguration.java
@@ -15,6 +15,7 @@ import com.compass.domain.chat.function.itinerary.SearchPlacesFunction;
 import com.compass.domain.chat.function.itinerary.ShowItineraryFunction;
 import com.compass.domain.chat.function.planning.DestinationSearchFunction;
 import com.compass.domain.chat.function.planning.GenerateTravelPlanFunction;
+import com.compass.domain.chat.function.planning.RecommendDestinationsFunction;
 import com.compass.domain.chat.function.processing.ExtractFlightInfoFunction;
 import com.compass.domain.chat.function.processing.ProcessImageFunction;
 import com.compass.domain.chat.function.processing.ProcessOCRFunction;
@@ -37,9 +38,11 @@ public class FunctionConfiguration {
 
     private final SubmitTravelFormFunction submitTravelFormFunction;
     private final ShowQuickInputFormFunction showQuickInputFormFunction;
-    // private final AskFollowUpQuestionFunction askFollowUpQuestionFunction; // TODO: 구현 필요
+    private final ContinueFollowUpFunction continueFollowUpFunction;
+    private final RecommendDestinationsFunction recommendDestinationsFunction;
+    private final AnalyzeUserInputFunction analyzeUserInputFunction;
     private final StartFollowUpFunction startFollowUpFunction;
-    // private final ValidateAndStoreInfoFunction validateAndStoreInfoFunction; // TODO: 구현 필요
+
 
     @Bean
     public FunctionCallbackWrapper<?, ?> submitTravelFormWrapper() {
@@ -57,14 +60,6 @@ public class FunctionConfiguration {
                 .build();
     }
 
-    // TODO: AskFollowUpQuestionFunction 구현 후 주석 해제
-    // @Bean
-    // public FunctionCallbackWrapper<?, ?> askFollowUpQuestionWrapper() {
-    //     return FunctionCallbackWrapper.builder(askFollowUpQuestionFunction)
-    //             .withName("ask_follow_up_question")
-    //             .withDescription("부족한 정보에 대한 추가 질문 생성")
-    //             .build();
-    // }
 
     @Bean
     public FunctionCallbackWrapper<?, ?> startFollowUpWrapper() {
@@ -74,14 +69,23 @@ public class FunctionConfiguration {
                 .build();
     }
 
-    // TODO: ValidateAndStoreInfoFunction 구현 후 주석 해제
-    // @Bean
-    // public FunctionCallbackWrapper<?, ?> validateAndStoreInfoWrapper() {
-    //     return FunctionCallbackWrapper.builder(validateAndStoreInfoFunction)
-    //             .withName("validate_and_store_info")
-    //             .withDescription("수집된 정보 검증 및 저장")
-    //             .build();
-    // }
+
+    @Bean
+    public FunctionCallbackWrapper<?, ?> continueFollowUpWrapper() {
+        return FunctionCallbackWrapper.builder(continueFollowUpFunction)
+                .withName("continueFollowUp")
+                .withDescription("사용자의 추가 답변을 처리하고, 모든 정보가 수집될 때까지 후속 질문을 계속합니다.")
+                .build();
+    }
+
+
+    @Bean
+    public FunctionCallbackWrapper<?, ?> recommendDestinationsWrapper() {
+        return FunctionCallbackWrapper.builder(recommendDestinationsFunction)
+                .withName("recommendDestinations")
+                .withDescription("사용자가 '목적지 미정'을 선택했을 경우, 출발지와 여행 스타일에 맞춰 적절한 여행지를 추천합니다.")
+                .build();
+    }
 
     // ========== 여행 계획 Functions (Planning) ==========
 

--- a/src/main/java/com/compass/domain/chat/function/planning/RecommendDestinationsFunction.java
+++ b/src/main/java/com/compass/domain/chat/function/planning/RecommendDestinationsFunction.java
@@ -12,7 +12,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
-// Task 2.3.1: "목적지 미정" 시 사용자에게 맞춤 목적지를 추천하는 Function
+// "목적지 미정" 시 사용자에게 맞춤 목적지를 추천
 
 @Slf4j
 @Component("recommendDestinations")

--- a/src/main/java/com/compass/domain/chat/parser/service/NaturalLanguageParser.java
+++ b/src/main/java/com/compass/domain/chat/parser/service/NaturalLanguageParser.java
@@ -2,8 +2,8 @@ package com.compass.domain.chat.parser.service;
 
 import com.compass.domain.chat.model.request.TravelFormSubmitRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Service;
 
@@ -12,11 +12,15 @@ import java.time.LocalDate;
 //  LLM을 이용해 자연어 입력을 분석하는 파서 구현체
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class NaturalLanguageParser implements TravelInfoParser {
 
     private final ChatClient.Builder chatClientBuilder;
     private final ObjectMapper objectMapper;
+
+    public NaturalLanguageParser(@Lazy ChatClient.Builder chatClientBuilder, ObjectMapper objectMapper) {
+        this.chatClientBuilder = chatClientBuilder;
+        this.objectMapper = objectMapper;
+    }
 
     // LLM 역할 정의 프롬프트 (한글 버전)
     private static final String PROMPT_TEMPLATE = """


### PR DESCRIPTION
## 📌 개요
- **Epic**: CHAT2 여행 정보 수집 시스템
- **Story**: S2.1. 기본 정보 수집 Function 구현, S2.4. Follow-up 및 추천 시스템
- **Task**: T2.1.2, T2.4.1, T2.4.2, T2.4.3
- **예상 소요시간**: 6시간
- **실제 소요시간**: 5시간

## 🎯 구현 목적
### 전체 시스템에서의 역할
- 이번 PR은 정보 수집 워크플로우의 핵심 4대 기능(`SubmitTravelForm`, `AnalyzeUserInput`, `StartFollowUp`, `ContinueFollowUp`)을 리팩토링하여, 각 Function이 **'조정자(Coordinator)'**의 역할에 집중하도록 구조를 개선합니다.
- 복잡한 비즈니스 로직은 새로 구현된 SOLID 기반 서비스 계층에 위임하고, Function들은 오케스트레이터와 서비스 계층을 잇는 경량의 '브릿지' 역할을 수행합니다.

### 이 코드가 필요한 이유
- **기존:** 각 Function 내부에 검증, 파싱, 질문 생성 등 여러 책임이 혼재되어 있어 SRP(단일 책임 원칙)에 위배되고 테스트가 복잡했습니다.
- **개선:** 각 Function의 책임을 명확히 분리하고, 실제 로직은 전문화된 서비스(`DefaultTravelInfoValidator`, `NaturalLanguageParser`, `FollowUpOrchestrator`, `TravelInfoCollectionService`)에 위임했습니다.
- **효과:** 코드의 재사용성과 테스트 용이성이 향상되었으며, 각 컴포넌트의 역할이 명확해져 전체 아키텍처의 유지보수성과 확장성이 크게 개선되었습니다.

## 🏗️ 설계 결정 사항
### 왜 이런 구조를 선택했는가?
1. **책임 위임(Delegation)을 통한 SRP 강화**
   - **이유:** Function이 모든 일을 직접 처리하는 대신, 각 분야의 '전문가'에게 작업을 위임하는 구조를 채택했습니다.
   - **`SubmitTravelFormFunction`** → `DefaultTravelInfoValidator`에게 **검증**을 위임
   - **`StartFollowUpFunction`** → `FollowUpOrchestrator`에게 **다음 질문 결정**을 위임
   - **`ContinueFollowUpFunction`** → `TravelInfoCollectionService`에게 **전체 수집 파이프라인 실행**을 위임
   - **`AnalyzeUserInputFunction`** → `NaturalLanguageParser`에게 **자연어 분석**을 위임
   - **장점:** 각 Function의 코드가 간결해지고, 책임이 명확해져 이해하고 테스트하기 쉬워졌습니다.

2. **Function을 서비스 계층의 Facade로 활용**
   - **이유:** 오케스트레이터는 복잡한 서비스 계층의 내부 구조를 알 필요 없이, 단순한 Function만 호출하면 되도록 설계했습니다.
   - **장점:** 오케스트레이터와 서비스 계층 간의 결합도를 낮추고, 향후 서비스 내부 로직이 변경되더라도 Function의 인터페이스만 유지된다면 오케스트레이터 코드는 수정할 필요가 없습니다.

## ✅ 구현 내용
### 주요 변경사항
- **`SubmitTravelFormFunction.java` 수정**:
    - `DefaultTravelInfoValidator`를 주입받아 `validate()`를 호출하고, 그 결과에 따라 `nextAction`을 분기 처리하도록 로직을 변경했습니다.
- **`AnalyzeUserInputFunction.java` 수정**:
    - `NaturalLanguageParser`를 주입받아 `parse()` 메서드를 호출하고 결과를 그대로 반환하는 간단한 Wrapper로 구조를 변경했습니다.
- **`StartFollowUpFunction.java` 수정**:
    - `FollowUpOrchestrator`를 주입받아 `determineNextQuestion()`을 호출하여 첫 질문을 생성하도록 로직을 변경했습니다.
- **`ContinueFollowUpFunction.java` 수정**:
    - `TravelInfoCollectionService`를 주입받아 `collectInfo`를 호출하고, 반환된 `CollectionResult`를 기반으로 `ChatResponse`를 생성하도록 전체 로직을 위임했습니다.

## 🔗 의존성 및 영향 범위
### 사용하는 컴포넌트
- `DefaultTravelInfoValidator`, `NaturalLanguageParser`, `FollowUpOrchestrator`, `TravelInfoCollectionService`

### 이 코드를 사용하는 곳
- `MainLLMOrchestrator`: 이 Function들을 호출하여 정보 수집 워크플로우를 진행합니다.

### 영향 범위
- 정보 수집 로직의 핵심이 Function 내부에서 서비스 계층으로 이동했습니다.
- 이제 각 Function의 단위 테스트는 실제 로직 수행이 아닌, **'올바른 서비스에 정확한 인자로 작업을 위임하는지'**를 검증하는 것에 초점을 맞춥니다.

## 🔄 다음 단계
- Epic 2의 모든 컴포넌트가 구현되었으므로, E2E(End-to-End) 통합 테스트를 통해 "여행 계획 짜줘" 요청부터 모든 정보가 수집되어 `TRIGGER_PLAN_GENERATION`이 반환되는 전체 워크플로우를 검증.